### PR TITLE
Fix UT-303 scheduler claim race duplicate dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.2.1]
+
+### Features ✨
+- _No changes._
+
+### Improvements ⚙️
+- _No changes._
+
+### Bug Fixes 🐛
+- Prevent duplicate side effects under worker contention by adding an optional scheduler claim hook (`ClaimingRepository`) that skips dispatch when claim ownership is lost.
+
+### Testing 🧪
+- Add scheduler regression tests for lost-claim and claim-error scenarios to ensure dispatch is skipped deterministically.
+
+### Docs 📚
+- _No changes._
+
 ## [v0.2.0]
 
 ### Features ✨

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Unexported helpers for strings, integers and booleans exist for internal tests.
 Retry-aware scheduling helpers.
 
 - **Worker** - Runs a periodic scan over pending jobs, applies exponential backoff, and persists attempt results via a repository interface.
+- **ClaimingRepository (optional)** - Lets repositories atomically claim a job before side effects run; when claim is lost, the worker skips dispatch to avoid duplicate execution under contention.
 
 ---
 
@@ -176,5 +177,4 @@ Contributions are welcome!
 ### **License**
 
 This project is licensed under the **MIT License**. See the **LICENSE** file for details.
-
 

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -12,6 +12,10 @@ Each issue is formatted as `- [ ] [UT-<number>]`. When resolved it becomes `- [x
 
 ## BugFixes (300–399)
 
+- [x] [UT-303] Skip dispatch when claim for attempt is lost. (Add optional claim hook in scheduler worker; skip dispatch/update when claim returns false or errors; add regression tests.)
+
+When multiple workers contend for the same pending entry, the scheduler can dispatch duplicate attempts unless the repository can atomically claim ownership before side effects run. Add a claim gate so workers skip dispatch when claim returns false.
+
 - [x] [UT-300] Close response body when transport returns both response and error. (Close response body on Do error; add regression test.)
 
 The error path after httpClient.Do returns immediately without closing the response body when Do returns both a response and an error. Per net/http this can happen for protocol errors or cancellations, and the caller must still close Response.Body; skipping it leaks the underlying connection and prevents keep-alives. Consider closing httpResponse.Body before returning the error.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -16,6 +16,11 @@ type Repository interface {
 	ApplyAttemptResult(ctx context.Context, job Job, update AttemptUpdate) error
 }
 
+// ClaimingRepository optionally provides an ownership claim gate before dispatch.
+type ClaimingRepository interface {
+	ClaimJobForAttempt(ctx context.Context, job Job, attemptedAt time.Time) (bool, error)
+}
+
 // Dispatcher performs the effectful work for a job (sending an email, firing an SMS, etc.).
 type Dispatcher interface {
 	Attempt(ctx context.Context, job Job) (DispatchResult, error)
@@ -154,6 +159,9 @@ func (worker *Worker) runCycle(ctx context.Context) {
 		if !worker.shouldAttempt(job, now) {
 			continue
 		}
+		if !worker.claimJob(ctx, job, now) {
+			continue
+		}
 		worker.executeJob(ctx, job, now)
 	}
 }
@@ -207,4 +215,21 @@ func (worker *Worker) executeJob(ctx context.Context, job Job, now time.Time) {
 	}
 
 	worker.logger.Info("scheduler_dispatch_success", "job_id", job.ID, "status", status)
+}
+
+func (worker *Worker) claimJob(ctx context.Context, job Job, now time.Time) bool {
+	claimingRepository, isClaimingRepository := worker.repository.(ClaimingRepository)
+	if !isClaimingRepository {
+		return true
+	}
+	claimed, claimErr := claimingRepository.ClaimJobForAttempt(ctx, job, now.UTC())
+	if claimErr != nil {
+		worker.logger.Error("scheduler_claim_error", "job_id", job.ID, "error", claimErr)
+		return false
+	}
+	if !claimed {
+		worker.logger.Info("scheduler_claim_lost", "job_id", job.ID)
+		return false
+	}
+	return true
 }

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -132,6 +132,64 @@ func TestWorkerDefaultsFailureStatusOnError(t *testing.T) {
 	}
 }
 
+func TestWorkerSkipsJobWhenClaimLost(t *testing.T) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	repo := &fakeClaimingRepository{
+		fakeRepository: fakeRepository{
+			jobs: []Job{
+				{ID: "job-claim"},
+			},
+		},
+		claimResults: []bool{false},
+	}
+	dispatcher := &fakeDispatcher{}
+
+	worker := newTestWorker(t, repo, dispatcher, now)
+	worker.RunOnce(context.Background())
+
+	if len(repo.claimedJobs) != 1 {
+		t.Fatalf("expected one claim attempt, got %d", len(repo.claimedJobs))
+	}
+	if len(dispatcher.calls) != 0 {
+		t.Fatalf("expected dispatcher not to run when claim is lost")
+	}
+	if len(repo.updates) != 0 {
+		t.Fatalf("expected no attempt update when claim is lost")
+	}
+}
+
+func TestWorkerSkipsJobWhenClaimFails(t *testing.T) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	repo := &fakeClaimingRepository{
+		fakeRepository: fakeRepository{
+			jobs: []Job{
+				{ID: "job-claim-error"},
+			},
+		},
+		claimErrors: []error{
+			assertionError("claim failed"),
+		},
+	}
+	dispatcher := &fakeDispatcher{}
+
+	worker := newTestWorker(t, repo, dispatcher, now)
+	worker.RunOnce(context.Background())
+
+	if len(repo.claimedJobs) != 1 {
+		t.Fatalf("expected one claim attempt, got %d", len(repo.claimedJobs))
+	}
+	if len(dispatcher.calls) != 0 {
+		t.Fatalf("expected dispatcher not to run when claim fails")
+	}
+	if len(repo.updates) != 0 {
+		t.Fatalf("expected no attempt update when claim fails")
+	}
+}
+
 // Helpers.
 
 type fakeRepository struct {
@@ -171,6 +229,31 @@ func (dispatcher *fakeDispatcher) Attempt(_ context.Context, job Job) (DispatchR
 		dispatcher.errors = dispatcher.errors[1:]
 	}
 	return result, err
+}
+
+type fakeClaimingRepository struct {
+	fakeRepository
+	claimResults []bool
+	claimErrors  []error
+	claimedJobs  []Job
+}
+
+func (repo *fakeClaimingRepository) ClaimJobForAttempt(_ context.Context, job Job, _ time.Time) (bool, error) {
+	repo.claimedJobs = append(repo.claimedJobs, job)
+
+	claimed := true
+	if len(repo.claimResults) > 0 {
+		claimed = repo.claimResults[0]
+		repo.claimResults = repo.claimResults[1:]
+	}
+
+	var err error
+	if len(repo.claimErrors) > 0 {
+		err = repo.claimErrors[0]
+		repo.claimErrors = repo.claimErrors[1:]
+	}
+
+	return claimed, err
 }
 
 type fixedClock struct {


### PR DESCRIPTION
## Summary
- add UT-303 bugfix entry and resolution to issues log
- add optional `ClaimingRepository` hook to scheduler worker and skip dispatch when claim is lost or errors
- add scheduler regression tests for lost-claim and claim-error contention scenarios
- update changelog (v0.2.1 section) and README scheduler docs

## Validation
- `timeout -k 350s -s SIGKILL 350s bash -lc 'test -z "$(gofmt -l .)" && go vet ./... && staticcheck ./... && ineffassign ./... && go test ./...'`
