### PR TITLE
Export EnsureLogger for downstream packages

### DIFF
--- a/crawler/interfaces.go
+++ b/crawler/interfaces.go
@@ -48,7 +48,8 @@ func SetPackageLogger(logger Logger) {
 	}
 }
 
-func ensureLogger(logger Logger) Logger {
+// EnsureLogger returns the provided logger if non-nil, otherwise a no-op logger.
+func EnsureLogger(logger Logger) Logger {
 	if logger == nil {
 		return noopLogger{}
 	}

--- a/crawler/service.go
+++ b/crawler/service.go
@@ -41,7 +41,7 @@ func NewService(cfg Config, results chan<- *Result, options ...ServiceOption) (*
 		return nil, err
 	}
 
-	logger := ensureLogger(cfg.Logger)
+	logger := EnsureLogger(cfg.Logger)
 	filePersister := cfg.FilePersister
 	if filePersister == nil && cfg.OutputDirectory != "" {
 		filePersister = newDirectoryFilePersister(cfg.OutputDirectory, cfg.PlatformID, cfg.RunFolder)

--- a/crawler/transport_safe.go
+++ b/crawler/transport_safe.go
@@ -20,7 +20,7 @@ func newPanicSafeTransport(base http.RoundTripper, logger Logger) http.RoundTrip
 	}
 	return &panicSafeTransport{
 		base:   effectiveBase,
-		logger: ensureLogger(logger),
+		logger: EnsureLogger(logger),
 	}
 }
 
@@ -56,7 +56,7 @@ func newPanicSafeReadCloser(body io.ReadCloser, url string, logger Logger) *pani
 	return &panicSafeReadCloser{
 		body:   body,
 		url:    url,
-		logger: ensureLogger(logger),
+		logger: EnsureLogger(logger),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Export the `ensureLogger` helper as `EnsureLogger` so downstream packages (e.g. `crawlerext`) can use it instead of duplicating the noopLogger fallback pattern.
- Update all internal callers (`transport_safe.go`, `service.go`) to use the exported name.

## Test plan
- [x] `go test ./crawler/...` passes
- [x] No breaking changes — only renamed unexported to exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)