### PR TITLE
feat(configfile): add strict YAML interpolation config loader

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ only the helpers they need.
   forwarding, and one-shot render helpers.
 - `configfile`: Strict YAML config loading with scalar-only environment
   interpolation, explicit missing-variable errors, no default-substitution
-  syntax, and known-field decoding.
+  syntax, single-document stream validation, and known-field decoding.
 - `crawler`: Shared crawling helpers, including provider/user-aware proxy lease
   selection and operation-scoped failed-lease tracking for scrape batches.
 - `file`: Filesystem helpers (delete, close, read/write convenience).
@@ -50,7 +50,9 @@ only the helpers they need.
 - `ProxyLeaseSelector` owns global provider/user rotation state. It keeps a
   successful lease sticky until failure, then advances to the next provider
   immediately while advancing the failed provider's next user for the next
-  return.
+  return. When all healthy leases are already reserved by in-flight requests, it
+  reuses the least-reserved healthy lease instead of treating reservations as
+  candidate exhaustion.
 - `ProxyLeaseAttemptScope` is caller-created for one scrape or request batch. It
   remembers which leases failed during that operation, skips those leases on
   later acquisitions, and returns `ErrProxyLeaseCandidatesExhausted` once every

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,9 @@ only the helpers they need.
 - `browsertransport`: Shared proxy-aware browser and HTTP transport runtime for
   scraping workloads, including browser profiles, reusable sessions, SOCKS
   forwarding, and one-shot render helpers.
+- `configfile`: Strict YAML config loading with scalar-only environment
+  interpolation, explicit missing-variable errors, no default-substitution
+  syntax, and known-field decoding.
 - `crawler`: Shared crawling helpers, including provider/user-aware proxy lease
   selection and operation-scoped failed-lease tracking for scrape batches.
 - `file`: Filesystem helpers (delete, close, read/write convenience).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes 🐛
+- Reuse the least-reserved healthy proxy lease when every configured lease is already reserved by in-flight requests.
+- Reject trailing YAML documents in `configfile` loads instead of silently ignoring documents after the first one.
+
+### Testing 🧪
+- Add a crawler regression covering saturated proxy lease selection through the public HTTP proxy selector path.
+- Add a configfile regression for multi-document YAML streams.
+
 ## [v0.15.1] - 2026-05-01
 
 ### Features ✨

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ projects.
 Reusable crawler primitives for proxy-aware scraping workloads.
 
 - **ProxyLeaseSelector** - Select provider/user-aware proxy leases, keep
-  successful leases sticky, and rotate providers immediately after a reported
+  successful leases sticky, reuse the least-reserved healthy lease under
+  concurrency saturation, and rotate providers immediately after a reported
   failure.
 - **ProxyLeaseAttemptScope** - Track failed leases for one scrape or request
   batch so callers can skip candidates that already failed during that
@@ -32,7 +33,8 @@ Strict YAML configuration loading for applications.
 
 - **LoadYAML(path string, target any) error** - Read a YAML config file, expand
   environment variables only inside YAML scalar values, reject missing
-  environment variables, and decode with known-field validation.
+  environment variables and trailing YAML documents, and decode with known-field
+  validation.
 - **LoadYAMLBytes(configPayload []byte, target any) error** - Apply the same
   contract to already-read YAML bytes.
 - **InterpolateYAML(configPayload []byte) ([]byte, error)** - Expand YAML scalar

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Reusable crawler primitives for proxy-aware scraping workloads.
   batch so callers can skip candidates that already failed during that
   operation and stop with a typed exhausted-candidates error.
 
+## Configfile
+Strict YAML configuration loading for applications.
+
+- **LoadYAML(path string, target any) error** - Read a YAML config file, expand
+  environment variables only inside YAML scalar values, reject missing
+  environment variables, and decode with known-field validation.
+- **LoadYAMLBytes(configPayload []byte, target any) error** - Apply the same
+  contract to already-read YAML bytes.
+- **InterpolateYAML(configPayload []byte) ([]byte, error)** - Expand YAML scalar
+  environment references before application-specific decoding.
+
 ## JSEval
 Compatibility wrapper around `browsertransport` for existing callers that only
 need one-shot page rendering.

--- a/configfile/configfile.go
+++ b/configfile/configfile.go
@@ -1,0 +1,295 @@
+// Package configfile loads YAML configuration files with strict environment
+// interpolation.
+package configfile
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	environmentNameExpression = `[A-Za-z_][A-Za-z0-9_]*`
+)
+
+var (
+	// ErrInvalidEnvironmentReference reports unsupported environment syntax in a
+	// YAML scalar.
+	ErrInvalidEnvironmentReference = errors.New("configfile.invalid_environment_reference")
+
+	// ErrMissingEnvironmentVariables reports YAML references to unset
+	// environment variables.
+	ErrMissingEnvironmentVariables = errors.New("configfile.missing_environment_variables")
+
+	// ErrMissingPath reports an empty config file path.
+	ErrMissingPath = errors.New("configfile.missing_path")
+
+	// ErrNilTarget reports a nil or non-pointer decode target.
+	ErrNilTarget = errors.New("configfile.nil_target")
+
+	// ErrParse reports malformed YAML or target decode failures.
+	ErrParse = errors.New("configfile.parse")
+
+	// ErrRead reports config file read failures.
+	ErrRead = errors.New("configfile.read")
+
+	wholeEnvironmentReferencePattern = regexp.MustCompile(`^\$(?:\{(` + environmentNameExpression + `)\}|(` + environmentNameExpression + `))$`)
+	environmentReferencePattern      = regexp.MustCompile(`\$\{([^}]*)\}|\$(` + environmentNameExpression + `)`)
+	environmentNamePattern           = regexp.MustCompile(`^` + environmentNameExpression + `$`)
+	marshalYAML                      = yaml.Marshal
+)
+
+// InvalidEnvironmentReferenceError identifies an unsupported interpolation
+// reference.
+type InvalidEnvironmentReferenceError struct {
+	Reference string
+}
+
+// Error returns a stable invalid-reference error string.
+func (invalidReferenceError InvalidEnvironmentReferenceError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrInvalidEnvironmentReference, invalidReferenceError.Reference)
+}
+
+// Is reports compatibility with ErrInvalidEnvironmentReference.
+func (invalidReferenceError InvalidEnvironmentReferenceError) Is(target error) bool {
+	return target == ErrInvalidEnvironmentReference
+}
+
+// MissingEnvironmentVariablesError identifies every unset environment variable
+// referenced by a YAML document.
+type MissingEnvironmentVariablesError struct {
+	Names []string
+}
+
+// Error returns a stable missing-environment error string.
+func (missingVariablesError MissingEnvironmentVariablesError) Error() string {
+	return fmt.Sprintf(
+		"%s: missing environment variables for config interpolation: %s",
+		ErrMissingEnvironmentVariables,
+		strings.Join(missingVariablesError.Names, ", "),
+	)
+}
+
+// Is reports compatibility with ErrMissingEnvironmentVariables.
+func (missingVariablesError MissingEnvironmentVariablesError) Is(target error) bool {
+	return target == ErrMissingEnvironmentVariables
+}
+
+// LoadYAML reads a YAML config file, expands environment variables only inside
+// YAML scalar nodes, and decodes the result with KnownFields enabled.
+func LoadYAML(path string, target any) error {
+	normalizedPath := strings.TrimSpace(path)
+	if normalizedPath == "" {
+		return fmt.Errorf("%w: config path is required", ErrMissingPath)
+	}
+
+	configPayload, readError := os.ReadFile(normalizedPath)
+	if readError != nil {
+		return fmt.Errorf("%w: path=%s: %w", ErrRead, normalizedPath, readError)
+	}
+
+	if loadError := LoadYAMLBytes(configPayload, target); loadError != nil {
+		return fmt.Errorf("configfile.load path=%s: %w", normalizedPath, loadError)
+	}
+	return nil
+}
+
+// LoadYAMLBytes expands environment variables only inside YAML scalar nodes and
+// decodes the result with KnownFields enabled.
+func LoadYAMLBytes(configPayload []byte, target any) error {
+	if targetError := validateDecodeTarget(target); targetError != nil {
+		return targetError
+	}
+
+	interpolatedConfigPayload, interpolationError := InterpolateYAML(configPayload)
+	if interpolationError != nil {
+		return interpolationError
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(interpolatedConfigPayload))
+	decoder.KnownFields(true)
+	if decodeError := decoder.Decode(target); decodeError != nil {
+		return fmt.Errorf("%w: %w", ErrParse, decodeError)
+	}
+
+	return nil
+}
+
+// InterpolateYAML expands environment variables only inside YAML scalar nodes.
+func InterpolateYAML(configPayload []byte) ([]byte, error) {
+	var rootNode yaml.Node
+	if unmarshalError := yaml.Unmarshal(configPayload, &rootNode); unmarshalError != nil {
+		return nil, fmt.Errorf("%w: %w", ErrParse, unmarshalError)
+	}
+
+	missingVariableSet := make(map[string]struct{})
+	if interpolationError := interpolateNode(&rootNode, missingVariableSet); interpolationError != nil {
+		return nil, interpolationError
+	}
+	if len(missingVariableSet) > 0 {
+		return nil, MissingEnvironmentVariablesError{Names: sortedNames(missingVariableSet)}
+	}
+
+	interpolatedPayload, marshalError := marshalYAML(&rootNode)
+	if marshalError != nil {
+		return nil, fmt.Errorf("%w: %w", ErrParse, marshalError)
+	}
+	return interpolatedPayload, nil
+}
+
+func validateDecodeTarget(target any) error {
+	if target == nil {
+		return ErrNilTarget
+	}
+	targetValue := reflect.ValueOf(target)
+	if targetValue.Kind() != reflect.Pointer || targetValue.IsNil() {
+		return ErrNilTarget
+	}
+	return nil
+}
+
+func interpolateNode(node *yaml.Node, missingVariableSet map[string]struct{}) error {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.ScalarNode {
+		if interpolationError := interpolateScalarNode(node, missingVariableSet); interpolationError != nil {
+			return interpolationError
+		}
+	}
+	for _, childNode := range node.Content {
+		if interpolationError := interpolateNode(childNode, missingVariableSet); interpolationError != nil {
+			return interpolationError
+		}
+	}
+	return nil
+}
+
+func interpolateScalarNode(node *yaml.Node, missingVariableSet map[string]struct{}) error {
+	if node == nil || node.Kind != yaml.ScalarNode || !strings.Contains(node.Value, "$") {
+		return nil
+	}
+
+	expandedWholeValue, isWholeReference := expandWholeEnvironmentReference(node.Value, missingVariableSet)
+	if isWholeReference {
+		applyInterpolatedScalarTag(node, expandedWholeValue)
+		return nil
+	}
+
+	expandedValue, changed, interpolationError := expandInlineEnvironmentReferences(node.Value, missingVariableSet)
+	if interpolationError != nil {
+		return interpolationError
+	}
+	if !changed {
+		return nil
+	}
+	node.Value = expandedValue
+	node.Tag = "!!str"
+	return nil
+}
+
+func expandWholeEnvironmentReference(value string, missingVariableSet map[string]struct{}) (string, bool) {
+	trimmedValue := strings.TrimSpace(value)
+	submatches := wholeEnvironmentReferencePattern.FindStringSubmatch(trimmedValue)
+	if len(submatches) == 0 {
+		return "", false
+	}
+
+	environmentName := submatches[1]
+	if environmentName == "" {
+		environmentName = submatches[2]
+	}
+	environmentValue, environmentFound := os.LookupEnv(environmentName)
+	if !environmentFound {
+		missingVariableSet[environmentName] = struct{}{}
+	}
+	return environmentValue, true
+}
+
+func expandInlineEnvironmentReferences(value string, missingVariableSet map[string]struct{}) (string, bool, error) {
+	changed := false
+	var invalidReferenceError error
+	expandedValue := environmentReferencePattern.ReplaceAllStringFunc(value, func(reference string) string {
+		if invalidReferenceError != nil {
+			return reference
+		}
+		environmentName, referenceError := environmentNameFromReference(reference)
+		if referenceError != nil {
+			invalidReferenceError = referenceError
+			return reference
+		}
+		changed = true
+		environmentValue, environmentFound := os.LookupEnv(environmentName)
+		if !environmentFound {
+			missingVariableSet[environmentName] = struct{}{}
+		}
+		return environmentValue
+	})
+	if invalidReferenceError != nil {
+		return "", false, invalidReferenceError
+	}
+	return expandedValue, changed, nil
+}
+
+func environmentNameFromReference(reference string) (string, error) {
+	if strings.HasPrefix(reference, "${") && strings.HasSuffix(reference, "}") {
+		environmentName := strings.TrimSuffix(strings.TrimPrefix(reference, "${"), "}")
+		if !environmentNamePattern.MatchString(environmentName) {
+			return "", InvalidEnvironmentReferenceError{Reference: reference}
+		}
+		return environmentName, nil
+	}
+	if strings.HasPrefix(reference, "$") {
+		return strings.TrimPrefix(reference, "$"), nil
+	}
+	return "", InvalidEnvironmentReferenceError{Reference: reference}
+}
+
+func applyInterpolatedScalarTag(node *yaml.Node, expandedValue string) {
+	trimmedValue := strings.TrimSpace(expandedValue)
+	node.Style = 0
+
+	if trimmedValue == "" {
+		node.Tag = "!!null"
+		node.Value = ""
+		return
+	}
+
+	if strings.EqualFold(trimmedValue, "true") || strings.EqualFold(trimmedValue, "false") {
+		node.Tag = "!!bool"
+		node.Value = strings.ToLower(trimmedValue)
+		return
+	}
+
+	if _, parseIntError := strconv.ParseInt(trimmedValue, 10, 64); parseIntError == nil {
+		node.Tag = "!!int"
+		node.Value = trimmedValue
+		return
+	}
+
+	if _, parseFloatError := strconv.ParseFloat(trimmedValue, 64); parseFloatError == nil {
+		node.Tag = "!!float"
+		node.Value = trimmedValue
+		return
+	}
+
+	node.Tag = "!!str"
+	node.Value = expandedValue
+}
+
+func sortedNames(nameSet map[string]struct{}) []string {
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/configfile/configfile.go
+++ b/configfile/configfile.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"regexp"
@@ -119,15 +120,18 @@ func LoadYAMLBytes(configPayload []byte, target any) error {
 	if decodeError := decoder.Decode(target); decodeError != nil {
 		return fmt.Errorf("%w: %w", ErrParse, decodeError)
 	}
+	if streamError := requireYAMLDecoderEOF(decoder); streamError != nil {
+		return streamError
+	}
 
 	return nil
 }
 
 // InterpolateYAML expands environment variables only inside YAML scalar nodes.
 func InterpolateYAML(configPayload []byte) ([]byte, error) {
-	var rootNode yaml.Node
-	if unmarshalError := yaml.Unmarshal(configPayload, &rootNode); unmarshalError != nil {
-		return nil, fmt.Errorf("%w: %w", ErrParse, unmarshalError)
+	rootNode, decodeError := decodeSingleYAMLDocument(configPayload)
+	if decodeError != nil {
+		return nil, decodeError
 	}
 
 	missingVariableSet := make(map[string]struct{})
@@ -143,6 +147,33 @@ func InterpolateYAML(configPayload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %w", ErrParse, marshalError)
 	}
 	return interpolatedPayload, nil
+}
+
+func decodeSingleYAMLDocument(configPayload []byte) (yaml.Node, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(configPayload))
+	var document yaml.Node
+	if decodeError := decoder.Decode(&document); decodeError != nil {
+		if errors.Is(decodeError, io.EOF) {
+			return yaml.Node{}, nil
+		}
+		return yaml.Node{}, fmt.Errorf("%w: %w", ErrParse, decodeError)
+	}
+	if streamError := requireYAMLDecoderEOF(decoder); streamError != nil {
+		return yaml.Node{}, streamError
+	}
+	return document, nil
+}
+
+func requireYAMLDecoderEOF(decoder *yaml.Decoder) error {
+	var trailingDocument yaml.Node
+	trailingDecodeError := decoder.Decode(&trailingDocument)
+	if errors.Is(trailingDecodeError, io.EOF) {
+		return nil
+	}
+	if trailingDecodeError != nil {
+		return fmt.Errorf("%w: %w", ErrParse, trailingDecodeError)
+	}
+	return fmt.Errorf("%w: trailing YAML document", ErrParse)
 }
 
 func validateDecodeTarget(target any) error {

--- a/configfile/configfile_test.go
+++ b/configfile/configfile_test.go
@@ -151,6 +151,56 @@ func TestLoadYAMLBytesRejectsUnknownFields(testingHandle *testing.T) {
 	}
 }
 
+func TestLoadYAMLBytesRejectsTrailingDocuments(testingHandle *testing.T) {
+	var decoded configFileFixture
+	loadError := LoadYAMLBytes([]byte(strings.TrimSpace(`
+server:
+  enabled: true
+---
+server:
+  max_workers: 12
+`)), &decoded)
+
+	if !errors.Is(loadError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", loadError)
+	}
+	if !strings.Contains(loadError.Error(), "trailing YAML document") {
+		testingHandle.Fatalf("expected trailing document error, got %v", loadError)
+	}
+}
+
+func TestLoadYAMLBytesRejectsTrailingDocumentAfterStrictDecode(testingHandle *testing.T) {
+	originalMarshalYAML := marshalYAML
+	marshalYAML = func(input any) ([]byte, error) {
+		return []byte("server: {}\n---\nserver: {}\n"), nil
+	}
+	testingHandle.Cleanup(func() {
+		marshalYAML = originalMarshalYAML
+	})
+
+	var decoded configFileFixture
+	loadError := LoadYAMLBytes([]byte("server: {}\n"), &decoded)
+	if !errors.Is(loadError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", loadError)
+	}
+	if !strings.Contains(loadError.Error(), "trailing YAML document") {
+		testingHandle.Fatalf("expected trailing document error, got %v", loadError)
+	}
+}
+
+func TestInterpolateYAMLAcceptsEmptyPayload(testingHandle *testing.T) {
+	if _, interpolateError := InterpolateYAML(nil); interpolateError != nil {
+		testingHandle.Fatalf("expected empty YAML payload to interpolate, got %v", interpolateError)
+	}
+}
+
+func TestInterpolateYAMLRejectsMalformedTrailingDocument(testingHandle *testing.T) {
+	_, interpolateError := InterpolateYAML([]byte("server: {}\n---\nserver: [\n"))
+	if !errors.Is(interpolateError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", interpolateError)
+	}
+}
+
 func TestInterpolateYAMLReportsMissingEnvironmentVariables(testingHandle *testing.T) {
 	testingHandle.Setenv(testScalarStringName, "available")
 	unsetEnvironment(testingHandle, testMissingEnvironmentNameA)

--- a/configfile/configfile_test.go
+++ b/configfile/configfile_test.go
@@ -1,0 +1,280 @@
+package configfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const (
+	testEmbeddedHostName        = "CONFIGFILE_TEST_HOST"
+	testMissingEnvironmentNameA = "CONFIGFILE_TEST_MISSING_A"
+	testMissingEnvironmentNameB = "CONFIGFILE_TEST_MISSING_B"
+	testScalarBooleanName       = "CONFIGFILE_TEST_BOOL"
+	testScalarEmptyName         = "CONFIGFILE_TEST_EMPTY"
+	testScalarFloatName         = "CONFIGFILE_TEST_FLOAT"
+	testScalarIntegerName       = "CONFIGFILE_TEST_INTEGER"
+	testScalarStringName        = "CONFIGFILE_TEST_STRING"
+)
+
+type configFileFixture struct {
+	Server configFileServerFixture `yaml:"server"`
+}
+
+type configFileServerFixture struct {
+	Enabled     bool     `yaml:"enabled"`
+	HostURL     string   `yaml:"host_url"`
+	LiteralCost string   `yaml:"literal_cost"`
+	MaxWorkers  int      `yaml:"max_workers"`
+	EmptyValue  *string  `yaml:"empty_value"`
+	Ratio       float64  `yaml:"ratio"`
+	Secret      string   `yaml:"secret"`
+	Names       []string `yaml:"names"`
+}
+
+func TestLoadYAMLReadsFileAndInterpolatesScalars(testingHandle *testing.T) {
+	testingHandle.Setenv(testScalarBooleanName, "true")
+	testingHandle.Setenv(testEmbeddedHostName, "config.example.com")
+	testingHandle.Setenv(testScalarIntegerName, "12")
+	testingHandle.Setenv(testScalarFloatName, "1.25")
+	testingHandle.Setenv(testScalarStringName, "secret-value")
+	testingHandle.Setenv(testScalarEmptyName, "")
+
+	configPath := writeConfigFile(testingHandle, strings.TrimSpace(`
+server:
+  enabled: $CONFIGFILE_TEST_BOOL
+  host_url: "https://${CONFIGFILE_TEST_HOST}/api"
+  literal_cost: "cost is $20"
+  max_workers: "${CONFIGFILE_TEST_INTEGER}"
+  empty_value: $CONFIGFILE_TEST_EMPTY
+  ratio: $CONFIGFILE_TEST_FLOAT
+  secret: "${CONFIGFILE_TEST_STRING}"
+  names:
+    - "$CONFIGFILE_TEST_STRING"
+`))
+
+	var decoded configFileFixture
+	loadError := LoadYAML(configPath, &decoded)
+	if loadError != nil {
+		testingHandle.Fatalf("LoadYAML returned error: %v", loadError)
+	}
+
+	if !decoded.Server.Enabled {
+		testingHandle.Fatal("expected enabled to be true")
+	}
+	if decoded.Server.HostURL != "https://config.example.com/api" {
+		testingHandle.Fatalf("unexpected host URL: %s", decoded.Server.HostURL)
+	}
+	if decoded.Server.LiteralCost != "cost is $20" {
+		testingHandle.Fatalf("unexpected literal cost: %s", decoded.Server.LiteralCost)
+	}
+	if decoded.Server.MaxWorkers != 12 {
+		testingHandle.Fatalf("unexpected max workers: %d", decoded.Server.MaxWorkers)
+	}
+	if decoded.Server.EmptyValue != nil {
+		testingHandle.Fatalf("expected empty whole environment reference to decode as nil, got %#v", decoded.Server.EmptyValue)
+	}
+	if decoded.Server.Ratio != 1.25 {
+		testingHandle.Fatalf("unexpected ratio: %f", decoded.Server.Ratio)
+	}
+	if decoded.Server.Secret != "secret-value" {
+		testingHandle.Fatalf("unexpected secret: %s", decoded.Server.Secret)
+	}
+	if !reflect.DeepEqual(decoded.Server.Names, []string{"secret-value"}) {
+		testingHandle.Fatalf("unexpected names: %#v", decoded.Server.Names)
+	}
+}
+
+func TestLoadYAMLRejectsEmptyPath(testingHandle *testing.T) {
+	var decoded configFileFixture
+	loadError := LoadYAML("   ", &decoded)
+	if !errors.Is(loadError, ErrMissingPath) {
+		testingHandle.Fatalf("expected ErrMissingPath, got %v", loadError)
+	}
+}
+
+func TestLoadYAMLWrapsReadFailure(testingHandle *testing.T) {
+	var decoded configFileFixture
+	loadError := LoadYAML(filepath.Join(testingHandle.TempDir(), "missing.yml"), &decoded)
+	if !errors.Is(loadError, ErrRead) {
+		testingHandle.Fatalf("expected ErrRead, got %v", loadError)
+	}
+}
+
+func TestLoadYAMLWrapsDecodeFailure(testingHandle *testing.T) {
+	configPath := writeConfigFile(testingHandle, "server:\n  unknown: true")
+	var decoded configFileFixture
+	loadError := LoadYAML(configPath, &decoded)
+	if !errors.Is(loadError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", loadError)
+	}
+}
+
+func TestLoadYAMLBytesRejectsInvalidTarget(testingHandle *testing.T) {
+	testCases := []struct {
+		name   string
+		target any
+	}{
+		{name: "nil", target: nil},
+		{name: "non pointer", target: configFileFixture{}},
+		{name: "nil pointer", target: (*configFileFixture)(nil)},
+	}
+
+	for _, testCase := range testCases {
+		testingHandle.Run(testCase.name, func(testingHandle *testing.T) {
+			loadError := LoadYAMLBytes([]byte("server: {}\n"), testCase.target)
+			if !errors.Is(loadError, ErrNilTarget) {
+				testingHandle.Fatalf("expected ErrNilTarget, got %v", loadError)
+			}
+		})
+	}
+}
+
+func TestLoadYAMLBytesReturnsInterpolationFailure(testingHandle *testing.T) {
+	unsetEnvironment(testingHandle, testMissingEnvironmentNameA)
+	var decoded configFileFixture
+	loadError := LoadYAMLBytes([]byte("server:\n  secret: $CONFIGFILE_TEST_MISSING_A\n"), &decoded)
+	if !errors.Is(loadError, ErrMissingEnvironmentVariables) {
+		testingHandle.Fatalf("expected ErrMissingEnvironmentVariables, got %v", loadError)
+	}
+}
+
+func TestLoadYAMLBytesRejectsUnknownFields(testingHandle *testing.T) {
+	var decoded configFileFixture
+	loadError := LoadYAMLBytes([]byte("server:\n  missing_field: true\n"), &decoded)
+	if !errors.Is(loadError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", loadError)
+	}
+}
+
+func TestInterpolateYAMLReportsMissingEnvironmentVariables(testingHandle *testing.T) {
+	testingHandle.Setenv(testScalarStringName, "available")
+	unsetEnvironment(testingHandle, testMissingEnvironmentNameA)
+	unsetEnvironment(testingHandle, testMissingEnvironmentNameB)
+
+	_, interpolateError := InterpolateYAML([]byte(strings.TrimSpace(`
+server:
+  first: ${CONFIGFILE_TEST_MISSING_B}
+  second: "$CONFIGFILE_TEST_MISSING_A"
+  third: "$CONFIGFILE_TEST_MISSING_B"
+  fourth: "prefix-$CONFIGFILE_TEST_MISSING_A"
+  available: "$CONFIGFILE_TEST_STRING"
+`)))
+
+	if !errors.Is(interpolateError, ErrMissingEnvironmentVariables) {
+		testingHandle.Fatalf("expected ErrMissingEnvironmentVariables, got %v", interpolateError)
+	}
+
+	var missingVariablesError MissingEnvironmentVariablesError
+	if !errors.As(interpolateError, &missingVariablesError) {
+		testingHandle.Fatalf("expected MissingEnvironmentVariablesError, got %T", interpolateError)
+	}
+	expectedNames := []string{testMissingEnvironmentNameA, testMissingEnvironmentNameB}
+	if !reflect.DeepEqual(missingVariablesError.Names, expectedNames) {
+		testingHandle.Fatalf("expected missing names %#v, got %#v", expectedNames, missingVariablesError.Names)
+	}
+}
+
+func TestInterpolateYAMLRejectsDefaultSyntax(testingHandle *testing.T) {
+	_, interpolateError := InterpolateYAML([]byte("server:\n  port: ${CONFIGFILE_TEST_PORT:-8080} ${CONFIGFILE_TEST_OTHER:-9090}\n"))
+	if !errors.Is(interpolateError, ErrInvalidEnvironmentReference) {
+		testingHandle.Fatalf("expected ErrInvalidEnvironmentReference, got %v", interpolateError)
+	}
+
+	var invalidReferenceError InvalidEnvironmentReferenceError
+	if !errors.As(interpolateError, &invalidReferenceError) {
+		testingHandle.Fatalf("expected InvalidEnvironmentReferenceError, got %T", interpolateError)
+	}
+	if invalidReferenceError.Reference != "${CONFIGFILE_TEST_PORT:-8080}" {
+		testingHandle.Fatalf("unexpected invalid reference: %s", invalidReferenceError.Reference)
+	}
+}
+
+func TestInterpolateYAMLWrapsMarshalFailure(testingHandle *testing.T) {
+	originalMarshalYAML := marshalYAML
+	marshalYAML = func(input any) ([]byte, error) {
+		return nil, fmt.Errorf("forced marshal failure")
+	}
+	testingHandle.Cleanup(func() {
+		marshalYAML = originalMarshalYAML
+	})
+
+	_, interpolateError := InterpolateYAML([]byte("server: {}\n"))
+	if !errors.Is(interpolateError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", interpolateError)
+	}
+}
+
+func TestInterpolateYAMLRejectsInvalidYAML(testingHandle *testing.T) {
+	_, interpolateError := InterpolateYAML([]byte("server: ["))
+	if !errors.Is(interpolateError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", interpolateError)
+	}
+}
+
+func TestInterpolateNodeAcceptsNilAndNonScalarNodes(testingHandle *testing.T) {
+	missingVariables := map[string]struct{}{}
+	if interpolationError := interpolateNode(nil, missingVariables); interpolationError != nil {
+		testingHandle.Fatalf("expected nil node to be ignored, got %v", interpolationError)
+	}
+	if interpolationError := interpolateScalarNode(nil, missingVariables); interpolationError != nil {
+		testingHandle.Fatalf("expected nil scalar to be ignored, got %v", interpolationError)
+	}
+	if environmentName, referenceError := environmentNameFromReference("$CONFIGFILE_TEST_DIRECT"); referenceError != nil || environmentName != "CONFIGFILE_TEST_DIRECT" {
+		testingHandle.Fatalf("expected direct environment name, got name=%s error=%v", environmentName, referenceError)
+	}
+	if _, referenceError := environmentNameFromReference("no-reference"); !errors.Is(referenceError, ErrInvalidEnvironmentReference) {
+		testingHandle.Fatalf("expected invalid environment reference, got %v", referenceError)
+	}
+}
+
+func TestErrorCompatibility(testingHandle *testing.T) {
+	missingVariablesError := MissingEnvironmentVariablesError{Names: []string{testMissingEnvironmentNameA}}
+	if !errors.Is(missingVariablesError, ErrMissingEnvironmentVariables) {
+		testingHandle.Fatal("expected missing-variable error compatibility")
+	}
+	if !strings.Contains(missingVariablesError.Error(), testMissingEnvironmentNameA) {
+		testingHandle.Fatalf("expected missing-variable error to include name, got %s", missingVariablesError.Error())
+	}
+
+	invalidReferenceError := InvalidEnvironmentReferenceError{Reference: "${BROKEN:-default}"}
+	if !errors.Is(invalidReferenceError, ErrInvalidEnvironmentReference) {
+		testingHandle.Fatal("expected invalid-reference error compatibility")
+	}
+	if !strings.Contains(invalidReferenceError.Error(), "${BROKEN:-default}") {
+		testingHandle.Fatalf("expected invalid-reference error to include reference, got %s", invalidReferenceError.Error())
+	}
+}
+
+func writeConfigFile(testingHandle *testing.T, payload string) string {
+	testingHandle.Helper()
+	configPath := filepath.Join(testingHandle.TempDir(), "config.yml")
+	writeError := os.WriteFile(configPath, []byte(payload+"\n"), 0o600)
+	if writeError != nil {
+		testingHandle.Fatalf("failed to write config fixture: %v", writeError)
+	}
+	return configPath
+}
+
+func unsetEnvironment(testingHandle *testing.T, environmentName string) {
+	testingHandle.Helper()
+	originalValue, hadOriginalValue := os.LookupEnv(environmentName)
+	if unsetError := os.Unsetenv(environmentName); unsetError != nil {
+		testingHandle.Fatalf("failed to unset %s: %v", environmentName, unsetError)
+	}
+	testingHandle.Cleanup(func() {
+		if hadOriginalValue {
+			if restoreError := os.Setenv(environmentName, originalValue); restoreError != nil {
+				testingHandle.Fatalf("failed to restore %s: %v", environmentName, restoreError)
+			}
+			return
+		}
+		if restoreError := os.Unsetenv(environmentName); restoreError != nil {
+			testingHandle.Fatalf("failed to keep %s unset: %v", environmentName, restoreError)
+		}
+	})
+}

--- a/crawler/config.go
+++ b/crawler/config.go
@@ -75,8 +75,17 @@ type ScraperConfig struct {
 	InsecureSkipVerify         bool
 	RateLimit                  time.Duration
 	ProxyList                  []string
+	ProxyLeaseSelector         *ProxyLeaseSelector
 	SaveFiles                  bool
 	ProxyCircuitBreakerEnabled bool
+}
+
+// ProxyCandidateCount reports the configured proxy candidate count.
+func (cfg ScraperConfig) ProxyCandidateCount() int {
+	if cfg.ProxyLeaseSelector != nil {
+		return cfg.ProxyLeaseSelector.CandidateCount()
+	}
+	return len(cfg.ProxyList)
 }
 
 // Validate checks that essential numeric fields are positive.

--- a/crawler/coverage_test.go
+++ b/crawler/coverage_test.go
@@ -1513,6 +1513,34 @@ func TestRecordProxyFailureNonZeroStatusCode(t *testing.T) {
 	require.Empty(t, tracker.failures)
 }
 
+func TestRecordProxyFailureNeutralStatusReleasesTrackedLease(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://proxy-one:8080"},
+			{Name: "user-two", URL: "http://proxy-two:8080"},
+		},
+	}})
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	resp := &colly.Response{
+		StatusCode: http.StatusNotFound,
+		Request: &colly.Request{
+			ProxyURL: lease.ProxyURL,
+			Ctx:      colly.NewContext(),
+		},
+	}
+	attachTrackedProxySelection(resp.Request, lease)
+
+	recordProxyFailure(selector, resp)
+
+	nextLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, lease.ProxyURL, nextLease.ProxyURL)
+}
+
 func TestRecordProxyFailureBadGatewayStatusCode(t *testing.T) {
 	tracker := &trackingProxyHealth{}
 	resp := &colly.Response{

--- a/crawler/coverage_test.go
+++ b/crawler/coverage_test.go
@@ -699,6 +699,29 @@ func TestRecordProxySuccessWithTracker(t *testing.T) {
 	require.Equal(t, []string{"http://proxy:8080"}, tracker.successes)
 }
 
+func TestRecordProxySuccessWithLeaseReporter(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://proxy:8080",
+		}},
+	}})
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	processor := &responseProcessor{proxyTracker: selector}
+	resp := newTestResponse("PROD")
+	resp.Request.ProxyURL = lease.ProxyURL
+	attachTrackedProxySelection(resp.Request, lease)
+
+	processor.recordProxySuccess(resp)
+	reusedLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, lease.ProxyURL, reusedLease.ProxyURL)
+}
+
 func TestRecordProxySuccessNoTracker(t *testing.T) {
 	processor := &responseProcessor{}
 	resp := newTestResponse("PROD")
@@ -712,6 +735,44 @@ func TestRecordProxySuccessEmptyProxyURL(t *testing.T) {
 	resp := newTestResponse("PROD")
 	processor.recordProxySuccess(resp)
 	require.Empty(t, tracker.successes)
+}
+
+func TestRecordCriticalProxyFailureWithLeaseReporter(t *testing.T) {
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{{
+			Name: "provider-one",
+			Users: []ProxyRotationUserConfig{{
+				Name: "user-one",
+				URL:  "http://proxy:8080",
+			}},
+		}},
+		ProxyLeaseSelectorCircuitBreaker(true),
+		ProxyLeaseSelectorClock(func() time.Time { return time.Unix(0, 0) }),
+	)
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	processor := &responseProcessor{proxyTracker: selector}
+	resp := newTestResponse("PROD")
+	resp.Request.ProxyURL = lease.ProxyURL
+	attachTrackedProxySelection(resp.Request, lease)
+
+	processor.recordCriticalProxyFailure(resp)
+	require.False(t, selector.IsAvailable(lease.ProxyURL))
+}
+
+func TestRecordCriticalProxyFailureBoundaryBranches(t *testing.T) {
+	processor := &responseProcessor{}
+	resp := newTestResponse("PROD")
+	resp.Request.ProxyURL = "http://proxy:8080"
+	require.NotPanics(t, func() { processor.recordCriticalProxyFailure(resp) })
+
+	tracker := &trackingProxyHealth{}
+	processor = &responseProcessor{proxyTracker: tracker}
+	resp.Request.ProxyURL = ""
+	processor.recordCriticalProxyFailure(resp)
+	require.Empty(t, tracker.criticalFailures)
 }
 
 func TestRetryByDecisionNilHandler(t *testing.T) {
@@ -1445,11 +1506,48 @@ func TestRecordProxyFailureEmptyProxyURL(t *testing.T) {
 func TestRecordProxyFailureNonZeroStatusCode(t *testing.T) {
 	tracker := &trackingProxyHealth{}
 	resp := &colly.Response{
-		StatusCode: http.StatusBadGateway,
+		StatusCode: http.StatusBadRequest,
 		Request:    &colly.Request{ProxyURL: "http://proxy:8080"},
 	}
 	recordProxyFailure(tracker, resp)
 	require.Empty(t, tracker.failures)
+}
+
+func TestRecordProxyFailureBadGatewayStatusCode(t *testing.T) {
+	tracker := &trackingProxyHealth{}
+	resp := &colly.Response{
+		StatusCode: http.StatusBadGateway,
+		Request:    &colly.Request{ProxyURL: "http://proxy:8080"},
+	}
+	recordProxyFailure(tracker, resp)
+	require.Equal(t, []string{"http://proxy:8080"}, tracker.failures)
+}
+
+func TestRecordProxyFailureWithLeaseReporter(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://proxy-one:8080"},
+			{Name: "user-two", URL: "http://proxy-two:8080"},
+		},
+	}})
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	resp := &colly.Response{
+		StatusCode: 0,
+		Request: &colly.Request{
+			ProxyURL: lease.ProxyURL,
+			Ctx:      colly.NewContext(),
+		},
+	}
+	attachTrackedProxySelection(resp.Request, lease)
+
+	recordProxyFailure(selector, resp)
+	nextLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://proxy-two:8080", nextLease.ProxyURL)
 }
 
 // ─── NewService with proxies and circuit breaker ──────────────────────────

--- a/crawler/proxy_health.go
+++ b/crawler/proxy_health.go
@@ -18,6 +18,10 @@ type proxyLeaseReporter interface {
 	ReportCriticalFailure(lease ProxyLease)
 }
 
+type proxyLeaseReleaser interface {
+	Release(lease ProxyLease)
+}
+
 type proxyHealthTracker struct {
 	logger           Logger
 	mu               sync.Mutex

--- a/crawler/proxy_health.go
+++ b/crawler/proxy_health.go
@@ -12,6 +12,12 @@ type proxyHealth interface {
 	RecordCriticalFailure(proxy string)
 }
 
+type proxyLeaseReporter interface {
+	ReportSuccess(lease ProxyLease)
+	ReportFailure(lease ProxyLease)
+	ReportCriticalFailure(lease ProxyLease)
+}
+
 type proxyHealthTracker struct {
 	logger           Logger
 	mu               sync.Mutex

--- a/crawler/proxy_lease_selector_test.go
+++ b/crawler/proxy_lease_selector_test.go
@@ -44,6 +44,38 @@ func TestProxyLeaseSelectorAcquiresDistinctLeasesAndReusesReleasedSuccess(t *tes
 	require.Equal(t, firstLease.ProxyURL, reusedLease.ProxyURL)
 }
 
+func TestProxyLeaseSelectorReusesLeastReservedHealthyLeaseWhenAllReserved(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://provider-one-user-one.example:8080"},
+			{Name: "user-two", URL: "http://provider-one-user-two.example:8080"},
+		},
+	}})
+	require.NoError(t, err)
+
+	firstLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	secondLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodGet, "https://example.com/product", nil)
+	require.NoError(t, err)
+	selectedProxyURL, err := selector.Select(request)
+	require.NoError(t, err)
+	require.Equal(t, firstLease.ProxyURL, selectedProxyURL.String())
+
+	selectedLease, found := SelectedProxySelection(request)
+	require.True(t, found)
+	require.Equal(t, firstLease.ProxyURL, selectedLease.ProxyURL)
+
+	leastReservedLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, secondLease.ProxyURL, leastReservedLease.ProxyURL)
+}
+
 func TestProxyLeaseSelectorAcquireForRequestReusesAttachedLease(t *testing.T) {
 	t.Parallel()
 
@@ -198,8 +230,9 @@ func TestProxyLeaseSelectorValidationDuplicateAndReleaseBranches(t *testing.T) {
 	require.Equal(t, "http://shared.example:8080", firstLease.ProxyURL)
 	require.Equal(t, "http://unique.example:8080", secondLease.ProxyURL)
 
-	_, err = selector.AcquireRequired()
-	require.ErrorIs(t, err, ErrProxyLeaseCandidatesExhausted)
+	saturatedLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, firstLease.ProxyURL, saturatedLease.ProxyURL)
 
 	selector.Release(firstLease)
 	reusedLease := selector.Acquire()
@@ -518,7 +551,8 @@ func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 
 	selector.reservations = map[string]int{"http://proxy-one.example:8080": 1}
 	lease := selector.Acquire()
-	require.False(t, lease.Valid())
+	require.True(t, lease.Valid())
+	require.Equal(t, "http://proxy-one.example:8080", lease.ProxyURL)
 
 	emptySelector := &ProxyLeaseSelector{reservations: map[string]int{}}
 	require.False(t, emptySelector.Acquire().Valid())

--- a/crawler/proxy_lease_selector_test.go
+++ b/crawler/proxy_lease_selector_test.go
@@ -44,6 +44,33 @@ func TestProxyLeaseSelectorAcquiresDistinctLeasesAndReusesReleasedSuccess(t *tes
 	require.Equal(t, firstLease.ProxyURL, reusedLease.ProxyURL)
 }
 
+func TestProxyLeaseSelectorAcquireForRequestReusesAttachedLease(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://provider-one-user-one.example:8080"},
+			{Name: "user-two", URL: "http://provider-one-user-two.example:8080"},
+		},
+	}})
+	require.NoError(t, err)
+	request, err := http.NewRequest(http.MethodGet, "https://example.com/product", nil)
+	require.NoError(t, err)
+	firstLease, err := selector.AcquireForRequest(request)
+	require.NoError(t, err)
+
+	redirectRequest := request.Clone(request.Context())
+	redirectLease, err := selector.AcquireForRequest(redirectRequest)
+	require.NoError(t, err)
+
+	require.Equal(t, firstLease, redirectLease)
+	selector.ReportSuccess(firstLease)
+	nextLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, firstLease.ProxyURL, nextLease.ProxyURL)
+}
+
 func TestProxyLeaseSelectorRotatesProviderImmediatelyAndAdvancesUserOnReturn(t *testing.T) {
 	t.Parallel()
 

--- a/crawler/proxy_lease_selector_test.go
+++ b/crawler/proxy_lease_selector_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/stretchr/testify/require"
@@ -166,15 +167,130 @@ func TestProxyLeaseSelectorValidationDuplicateAndReleaseBranches(t *testing.T) {
 
 	firstLease := selector.Acquire()
 	secondLease := selector.Acquire()
-	thirdLease := selector.Acquire()
 
 	require.Equal(t, "http://shared.example:8080", firstLease.ProxyURL)
 	require.Equal(t, "http://unique.example:8080", secondLease.ProxyURL)
-	require.Equal(t, "http://shared.example:8080", thirdLease.ProxyURL)
+
+	_, err = selector.AcquireRequired()
+	require.ErrorIs(t, err, ErrProxyLeaseCandidatesExhausted)
 
 	selector.Release(firstLease)
 	reusedLease := selector.Acquire()
 	require.Equal(t, firstLease.ProxyURL, reusedLease.ProxyURL)
+}
+
+func TestProxyLeaseSelectorCooldownSkipsPausedLeasesAndExhausts(t *testing.T) {
+	t.Parallel()
+
+	currentTime := time.Unix(0, 0)
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{
+			{
+				Name: "provider-one",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-one.example:8080"},
+					{Name: "user-two", URL: "http://provider-two.example:8080"},
+				},
+			},
+		},
+		ProxyLeaseSelectorCircuitBreaker(true),
+		ProxyLeaseSelectorClock(func() time.Time { return currentTime }),
+	)
+	require.NoError(t, err)
+
+	firstLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://provider-one.example:8080", firstLease.ProxyURL)
+
+	selector.ReportCriticalFailure(firstLease)
+	require.False(t, selector.IsAvailable(firstLease.ProxyURL))
+	require.True(t, selector.IsAvailable(""))
+	selector.RecordCriticalFailure("http://unknown.example:8080")
+
+	secondLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://provider-two.example:8080", secondLease.ProxyURL)
+
+	selector.ReportCriticalFailure(secondLease)
+	_, err = selector.AcquireRequired()
+	require.ErrorIs(t, err, ErrProxyLeaseCandidatesExhausted)
+
+	currentTime = currentTime.Add(defaultProxyCooldownBase + time.Second)
+	recoveredLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://provider-one.example:8080", recoveredLease.ProxyURL)
+	selector.ReportSuccess(recoveredLease)
+	require.True(t, selector.IsAvailable(recoveredLease.ProxyURL))
+
+	recoveredLease, err = selector.AcquireRequired()
+	require.NoError(t, err)
+	selector.RecordCriticalFailure(recoveredLease.ProxyURL)
+	require.False(t, selector.IsAvailable(recoveredLease.ProxyURL))
+}
+
+func TestProxyLeaseSelectorStartsAtConfiguredProvider(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{
+			{
+				Name: "provider-one",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-one.example:8080"},
+				},
+			},
+			{
+				Name: "provider-two",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-two.example:8080"},
+				},
+			},
+		},
+		ProxyLeaseSelectorStartProvider(1),
+	)
+	require.NoError(t, err)
+
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "provider-two", lease.ProviderName)
+	require.Equal(t, "http://provider-two.example:8080", lease.ProxyURL)
+
+	selector, err = NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{
+			{
+				Name: "provider-one",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-one.example:8080"},
+				},
+			},
+		},
+		ProxyLeaseSelectorStartProvider(-1),
+	)
+	require.NoError(t, err)
+	lease, err = selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "provider-one", lease.ProviderName)
+	require.Equal(t, 0, normalizeProxyProviderIndex(0, 0))
+}
+
+func TestProxyLeaseSelectorRecordsNonCriticalFailureWithCooldownTracker(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{{
+			Name: "provider-one",
+			Users: []ProxyRotationUserConfig{{
+				Name: "user-one",
+				URL:  "http://provider-one.example:8080",
+			}},
+		}},
+		ProxyLeaseSelectorCircuitBreaker(true),
+	)
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	selector.ReportFailure(lease)
 }
 
 func TestProxyLeaseSelectorAcquireForRequestAttachesSelection(t *testing.T) {
@@ -221,6 +337,9 @@ func TestProxyLeaseSelectorCompatibilityStringReports(t *testing.T) {
 	selector.ReportSuccess(ProxyLease{})
 	selector.RecordFailure("http://unknown.example:8080")
 	selector.RecordSuccess("http://unknown.example:8080")
+	selector.RecordCriticalFailure("http://unknown.example:8080")
+	var nilSelector *ProxyLeaseSelector
+	nilSelector.RecordCriticalFailure("http://unknown.example:8080")
 	selector.RecordSuccess(lease.ProxyURL)
 
 	reusedLease := selector.Acquire()
@@ -313,6 +432,22 @@ func TestProxyLeaseUnavailableErrorWraps(t *testing.T) {
 	require.True(t, errors.Is(err, ErrProxyLeaseUnavailable))
 }
 
+func TestScraperConfigProxyCandidateCountPrefersSelector(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://proxy-one.example:8080"},
+			{Name: "user-two", URL: "http://proxy-two.example:8080"},
+		},
+	}})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, (ScraperConfig{ProxyLeaseSelector: selector, ProxyList: []string{"http://legacy.example:8080"}}).ProxyCandidateCount())
+	require.Equal(t, 1, (ScraperConfig{ProxyList: []string{"http://legacy.example:8080"}}).ProxyCandidateCount())
+}
+
 func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 	t.Parallel()
 
@@ -356,10 +491,11 @@ func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 
 	selector.reservations = map[string]int{"http://proxy-one.example:8080": 1}
 	lease := selector.Acquire()
-	require.Equal(t, "http://proxy-one.example:8080", lease.ProxyURL)
+	require.False(t, lease.Valid())
 
 	emptySelector := &ProxyLeaseSelector{reservations: map[string]int{}}
 	require.False(t, emptySelector.Acquire().Valid())
+	require.False(t, emptySelector.acquireLocked().Valid())
 
 	selection, found = selector.SelectionForProxyURL(" ")
 	require.False(t, found)
@@ -381,4 +517,10 @@ func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 	proxyURL, err := rotationSelector.Select(request)
 	require.Error(t, err)
 	require.Nil(t, proxyURL)
+
+	selector.recordFailureLocked("http://proxy-one.example:8080")
+	selector.recordSuccessLocked("http://proxy-one.example:8080")
+	selector.reservations = map[string]int{"http://proxy-one.example:8080": 2}
+	selector.Release(ProxyLease{ProxyURL: "http://proxy-one.example:8080"})
+	require.Equal(t, 1, selector.reservations["http://proxy-one.example:8080"])
 }

--- a/crawler/proxy_rotation_selector.go
+++ b/crawler/proxy_rotation_selector.go
@@ -539,7 +539,7 @@ func (selector *ProxyLeaseSelector) acquireLocked() ProxyLease {
 		}
 	}
 
-	return ProxyLease{}
+	return selector.leastReservedAvailableLeaseLocked()
 }
 
 func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(providerIndex int) (ProxyLease, bool) {
@@ -568,6 +568,37 @@ func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(provi
 		return selector.leaseForProviderUser(provider, candidateUser), true
 	}
 	return ProxyLease{}, false
+}
+
+func (selector *ProxyLeaseSelector) leastReservedAvailableLeaseLocked() ProxyLease {
+	selectedReservationCount := 0
+	var selectedLease ProxyLease
+
+	for providerOffset := 0; providerOffset < len(selector.providers); providerOffset++ {
+		providerIndex := (selector.activeProvider + providerOffset) % len(selector.providers)
+		provider := selector.providers[providerIndex]
+		if len(provider.users) == 0 {
+			continue
+		}
+		userIndex := provider.nextUser
+		if userIndex < 0 || userIndex >= len(provider.users) {
+			userIndex = 0
+		}
+		for userOffset := 0; userOffset < len(provider.users); userOffset++ {
+			candidateUserIndex := (userIndex + userOffset) % len(provider.users)
+			candidateUser := provider.users[candidateUserIndex]
+			if !selector.isAvailableLocked(candidateUser.raw) {
+				continue
+			}
+			reservationCount := selector.reservations[candidateUser.raw]
+			if !selectedLease.Valid() || reservationCount < selectedReservationCount {
+				selectedLease = selector.leaseForProviderUser(provider, candidateUser)
+				selectedReservationCount = reservationCount
+			}
+		}
+	}
+
+	return selectedLease
 }
 
 func (selector *ProxyLeaseSelector) leaseForProviderUser(provider proxyRotationProvider, user proxyRotationUser) ProxyLease {

--- a/crawler/proxy_rotation_selector.go
+++ b/crawler/proxy_rotation_selector.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 )
@@ -65,6 +66,46 @@ type proxyRotationProvider struct {
 	nextUser int
 }
 
+type proxyLeaseSelectorOptions struct {
+	circuitBreakerEnabled bool
+	startProviderIndex    int
+	hasStartProviderIndex bool
+	logger                Logger
+	now                   func() time.Time
+}
+
+// ProxyLeaseSelectorOption configures proxy lease selector runtime behavior.
+type ProxyLeaseSelectorOption func(*proxyLeaseSelectorOptions)
+
+// ProxyLeaseSelectorCircuitBreaker enables or disables cooldown tracking.
+func ProxyLeaseSelectorCircuitBreaker(enabled bool) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.circuitBreakerEnabled = enabled
+	}
+}
+
+// ProxyLeaseSelectorStartProvider sets the initial active provider index.
+func ProxyLeaseSelectorStartProvider(index int) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.startProviderIndex = index
+		options.hasStartProviderIndex = true
+	}
+}
+
+// ProxyLeaseSelectorLogger sets the selector logger used for cooldown notices.
+func ProxyLeaseSelectorLogger(logger Logger) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.logger = logger
+	}
+}
+
+// ProxyLeaseSelectorClock injects the selector clock for deterministic tests.
+func ProxyLeaseSelectorClock(now func() time.Time) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.now = now
+	}
+}
+
 // ProxyLeaseSelector acquires proxy leases from ordered providers and keeps
 // successful leases sticky until a failure advances rotation.
 type ProxyLeaseSelector struct {
@@ -74,6 +115,7 @@ type ProxyLeaseSelector struct {
 	activeProvider   int
 	generation       uint64
 	reservations     map[string]int
+	healthTracker    *proxyHealthTracker
 }
 
 // ProxyLeaseAttemptScope tracks failed proxy leases for one scrape, request
@@ -85,8 +127,22 @@ type ProxyLeaseAttemptScope struct {
 
 // NewProxyLeaseSelector constructs a provider-aware lease selector.
 func NewProxyLeaseSelector(configs []ProxyRotationProviderConfig) (*ProxyLeaseSelector, error) {
+	return NewProxyLeaseSelectorWithOptions(configs)
+}
+
+// NewProxyLeaseSelectorWithOptions constructs a provider-aware lease selector
+// with runtime options such as cooldowns and initial provider position.
+func NewProxyLeaseSelectorWithOptions(configs []ProxyRotationProviderConfig, optionList ...ProxyLeaseSelectorOption) (*ProxyLeaseSelector, error) {
+	options := proxyLeaseSelectorOptions{}
+	for _, option := range optionList {
+		if option != nil {
+			option(&options)
+		}
+	}
+
 	providers := make([]proxyRotationProvider, 0, len(configs))
 	selectionByProxy := make(map[string]proxySelectionIndex)
+	proxyURLs := make([]string, 0)
 	for _, providerConfig := range configs {
 		providerName := strings.TrimSpace(providerConfig.Name)
 		if providerName == "" {
@@ -120,6 +176,7 @@ func NewProxyLeaseSelector(configs []ProxyRotationProviderConfig) (*ProxyLeaseSe
 				raw:    trimmedProxyURL,
 				parsed: parsedProxyURL,
 			})
+			proxyURLs = append(proxyURLs, trimmedProxyURL)
 		}
 		if len(users) == 0 {
 			continue
@@ -132,10 +189,26 @@ func NewProxyLeaseSelector(configs []ProxyRotationProviderConfig) (*ProxyLeaseSe
 	if len(providers) == 0 {
 		return nil, nil
 	}
+
+	activeProvider := 0
+	if options.hasStartProviderIndex {
+		activeProvider = normalizeProxyProviderIndex(options.startProviderIndex, len(providers))
+	}
+
+	var healthTracker *proxyHealthTracker
+	if options.circuitBreakerEnabled {
+		healthTracker = newProxyHealthTracker(proxyURLs, options.logger)
+		if options.now != nil {
+			healthTracker.now = options.now
+		}
+	}
+
 	return &ProxyLeaseSelector{
 		providers:        providers,
 		selectionByProxy: selectionByProxy,
+		activeProvider:   activeProvider,
 		reservations:     map[string]int{},
+		healthTracker:    healthTracker,
 	}, nil
 }
 
@@ -147,28 +220,14 @@ func NewProxyLeaseAttemptScope() *ProxyLeaseAttemptScope {
 
 // Acquire reserves and returns the best current proxy lease.
 func (selector *ProxyLeaseSelector) Acquire() ProxyLease {
-	if selector == nil {
-		return ProxyLease{}
-	}
-
-	selector.mu.Lock()
-	defer selector.mu.Unlock()
-
-	lease := selector.acquireLocked()
-	if lease.Valid() {
-		selector.reservations[lease.ProxyURL]++
-	}
+	lease, _ := selector.acquire()
 	return lease
 }
 
 // AcquireRequired reserves and returns a proxy lease or a typed unavailable
 // error when no proxy is configured.
 func (selector *ProxyLeaseSelector) AcquireRequired() (ProxyLease, error) {
-	lease := selector.Acquire()
-	if !lease.Valid() {
-		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
-	}
-	return lease, nil
+	return selector.acquire()
 }
 
 // CandidateCount returns the number of configured proxy candidates.
@@ -198,6 +257,16 @@ func (selector *ProxyLeaseSelector) AcquireForRequest(request *http.Request) (Pr
 	return lease, nil
 }
 
+// Select returns the currently active provider/user tuple as a Colly proxy
+// function.
+func (selector *ProxyLeaseSelector) Select(request *http.Request) (*url.URL, error) {
+	lease, err := selector.AcquireForRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	return lease.proxyURL()
+}
+
 // Release releases a previously acquired lease reservation without reporting
 // success or failure.
 func (selector *ProxyLeaseSelector) Release(lease ProxyLease) {
@@ -213,6 +282,15 @@ func (selector *ProxyLeaseSelector) Release(lease ProxyLease) {
 
 // ReportFailure releases a lease and rotates immediately to the next provider.
 func (selector *ProxyLeaseSelector) ReportFailure(lease ProxyLease) {
+	selector.reportFailure(lease, false)
+}
+
+// ReportCriticalFailure releases a lease and immediately cools the proxy.
+func (selector *ProxyLeaseSelector) ReportCriticalFailure(lease ProxyLease) {
+	selector.reportFailure(lease, true)
+}
+
+func (selector *ProxyLeaseSelector) reportFailure(lease ProxyLease, critical bool) {
 	if selector == nil || !lease.Valid() {
 		return
 	}
@@ -222,7 +300,15 @@ func (selector *ProxyLeaseSelector) ReportFailure(lease ProxyLease) {
 
 	selector.releaseLocked(lease)
 	selectionIndex, found := selector.selectionByProxy[strings.TrimSpace(lease.ProxyURL)]
-	if !found || lease.Generation != selector.generation {
+	if !found {
+		return
+	}
+	if critical {
+		selector.recordCriticalFailureLocked(lease.ProxyURL)
+	} else {
+		selector.recordFailureLocked(lease.ProxyURL)
+	}
+	if lease.Generation != selector.generation {
 		return
 	}
 
@@ -253,6 +339,7 @@ func (selector *ProxyLeaseSelector) ReportSuccess(lease ProxyLease) {
 	if !found || lease.Generation != selector.generation {
 		return
 	}
+	selector.recordSuccessLocked(lease.ProxyURL)
 
 	provider := &selector.providers[selectionIndex.provider]
 	activeUserIndex := provider.nextUser % len(provider.users)
@@ -280,6 +367,25 @@ func (selector *ProxyLeaseSelector) RecordSuccess(proxyURL string) {
 		return
 	}
 	selector.ReportSuccess(selection)
+}
+
+// RecordCriticalFailure keeps string-only callers compatible.
+func (selector *ProxyLeaseSelector) RecordCriticalFailure(proxyURL string) {
+	selection, found := selector.SelectionForProxyURL(proxyURL)
+	if !found {
+		return
+	}
+	selector.ReportCriticalFailure(selection)
+}
+
+// IsAvailable reports whether a proxy is outside cooldown.
+func (selector *ProxyLeaseSelector) IsAvailable(proxyURL string) bool {
+	if selector == nil || strings.TrimSpace(proxyURL) == "" {
+		return true
+	}
+	selector.mu.Lock()
+	defer selector.mu.Unlock()
+	return selector.isAvailableLocked(proxyURL)
 }
 
 // SelectionForProxyURL returns the current-generation selection metadata for a
@@ -389,6 +495,29 @@ func proxyLeaseAttemptScopeKey(lease ProxyLease) string {
 	}, "\x00")
 }
 
+func (selector *ProxyLeaseSelector) acquire() (ProxyLease, error) {
+	if selector == nil {
+		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
+	}
+
+	selector.mu.Lock()
+	defer selector.mu.Unlock()
+
+	if len(selector.providers) == 0 {
+		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
+	}
+	candidateCount := selector.candidateCountLocked()
+	if candidateCount == 0 {
+		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
+	}
+	lease := selector.acquireLocked()
+	if !lease.Valid() {
+		return ProxyLease{}, ProxyLeaseCandidatesExhaustedError(candidateCount)
+	}
+	selector.reservations[lease.ProxyURL]++
+	return lease, nil
+}
+
 func (selector *ProxyLeaseSelector) acquireLocked() ProxyLease {
 	if len(selector.providers) == 0 {
 		return ProxyLease{}
@@ -407,7 +536,7 @@ func (selector *ProxyLeaseSelector) acquireLocked() ProxyLease {
 		}
 	}
 
-	return selector.leastReservedLeaseLocked()
+	return ProxyLease{}
 }
 
 func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(providerIndex int) (ProxyLease, bool) {
@@ -430,38 +559,12 @@ func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(provi
 		if selector.reservations[candidateUser.raw] > 0 {
 			continue
 		}
+		if !selector.isAvailableLocked(candidateUser.raw) {
+			continue
+		}
 		return selector.leaseForProviderUser(provider, candidateUser), true
 	}
 	return ProxyLease{}, false
-}
-
-func (selector *ProxyLeaseSelector) leastReservedLeaseLocked() ProxyLease {
-	fallbackLease := ProxyLease{}
-	fallbackReservations := 0
-	fallbackSet := false
-	for providerOffset := 0; providerOffset < len(selector.providers); providerOffset++ {
-		providerIndex := (selector.activeProvider + providerOffset) % len(selector.providers)
-		provider := selector.providers[providerIndex]
-		if len(provider.users) == 0 {
-			continue
-		}
-		userIndex := provider.nextUser
-		if userIndex < 0 || userIndex >= len(provider.users) {
-			userIndex = 0
-		}
-		for userOffset := 0; userOffset < len(provider.users); userOffset++ {
-			candidateUserIndex := (userIndex + userOffset) % len(provider.users)
-			candidateUser := provider.users[candidateUserIndex]
-			reservations := selector.reservations[candidateUser.raw]
-			if fallbackSet && reservations >= fallbackReservations {
-				continue
-			}
-			fallbackLease = selector.leaseForProviderUser(provider, candidateUser)
-			fallbackReservations = reservations
-			fallbackSet = true
-		}
-	}
-	return fallbackLease
 }
 
 func (selector *ProxyLeaseSelector) leaseForProviderUser(provider proxyRotationProvider, user proxyRotationUser) ProxyLease {
@@ -473,6 +576,44 @@ func (selector *ProxyLeaseSelector) leaseForProviderUser(provider proxyRotationP
 	}
 }
 
+func (lease ProxyLease) proxyURL() (*url.URL, error) {
+	parsedProxyURL, err := url.Parse(lease.ProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("proxy lease selector: invalid selected proxy URL %q: %w", lease.ProxyURL, err)
+	}
+	return parsedProxyURL, nil
+}
+
+func (selector *ProxyLeaseSelector) candidateCountLocked() int {
+	candidateCount := 0
+	for _, provider := range selector.providers {
+		candidateCount += len(provider.users)
+	}
+	return candidateCount
+}
+
+func (selector *ProxyLeaseSelector) isAvailableLocked(proxyURL string) bool {
+	return selector.healthTracker == nil || selector.healthTracker.IsAvailable(proxyURL)
+}
+
+func (selector *ProxyLeaseSelector) recordSuccessLocked(proxyURL string) {
+	if selector.healthTracker != nil {
+		selector.healthTracker.RecordSuccess(proxyURL)
+	}
+}
+
+func (selector *ProxyLeaseSelector) recordFailureLocked(proxyURL string) {
+	if selector.healthTracker != nil {
+		selector.healthTracker.RecordFailure(proxyURL)
+	}
+}
+
+func (selector *ProxyLeaseSelector) recordCriticalFailureLocked(proxyURL string) {
+	if selector.healthTracker != nil {
+		selector.healthTracker.RecordCriticalFailure(proxyURL)
+	}
+}
+
 func (selector *ProxyLeaseSelector) releaseLocked(lease ProxyLease) {
 	reservations := selector.reservations[strings.TrimSpace(lease.ProxyURL)]
 	switch {
@@ -481,6 +622,13 @@ func (selector *ProxyLeaseSelector) releaseLocked(lease ProxyLease) {
 	default:
 		selector.reservations[strings.TrimSpace(lease.ProxyURL)] = reservations - 1
 	}
+}
+
+func normalizeProxyProviderIndex(index int, providerCount int) int {
+	if providerCount <= 0 {
+		return 0
+	}
+	return ((index % providerCount) + providerCount) % providerCount
 }
 
 // ProxyRotationSelector keeps one (provider, user) selection sticky until a
@@ -507,17 +655,11 @@ func (selector *ProxyRotationSelector) Select(request *http.Request) (*url.URL, 
 	if selector == nil || selector.leaseSelector == nil {
 		return nil, nil
 	}
-
-	lease := selector.leaseSelector.Acquire()
-	if !lease.Valid() {
+	proxyURL, err := selector.leaseSelector.Select(request)
+	if errors.Is(err, ErrProxyLeaseUnavailable) {
 		return nil, nil
 	}
-	AttachProxySelection(request, lease)
-	parsedProxyURL, err := url.Parse(lease.ProxyURL)
-	if err != nil {
-		return nil, fmt.Errorf("proxy rotation selector: invalid selected proxy URL %q: %w", lease.ProxyURL, err)
-	}
-	return parsedProxyURL, nil
+	return proxyURL, err
 }
 
 // RecordFailure keeps string-only callers compatible.
@@ -543,6 +685,14 @@ func (selector *ProxyRotationSelector) RecordProxyFailure(selection ProxySelecti
 		return
 	}
 	selector.leaseSelector.ReportFailure(selection)
+}
+
+// RecordProxyCriticalFailure cools the selected proxy immediately.
+func (selector *ProxyRotationSelector) RecordProxyCriticalFailure(selection ProxySelection) {
+	if selector == nil || selector.leaseSelector == nil {
+		return
+	}
+	selector.leaseSelector.ReportCriticalFailure(selection)
 }
 
 // RecordProxySuccess makes the successful provider/user tuple sticky until the

--- a/crawler/proxy_rotation_selector.go
+++ b/crawler/proxy_rotation_selector.go
@@ -249,6 +249,9 @@ func (selector *ProxyLeaseSelector) CandidateCount() int {
 // AcquireForRequest reserves a lease and attaches it to the request context for
 // HTTP and Colly callers.
 func (selector *ProxyLeaseSelector) AcquireForRequest(request *http.Request) (ProxyLease, error) {
+	if selection, found := SelectedProxySelection(request); found {
+		return selection, nil
+	}
 	lease, err := selector.AcquireRequired()
 	if err != nil {
 		return ProxyLease{}, err

--- a/crawler/proxy_rotation_selector_test.go
+++ b/crawler/proxy_rotation_selector_test.go
@@ -269,6 +269,9 @@ func TestProxyRotationSelectorNilEmptyAndUnknownBranches(t *testing.T) {
 	require.NotPanics(t, func() { nilSelector.RecordFailure("http://unknown.example:8080") })
 	require.NotPanics(t, func() { nilSelector.RecordSuccess("http://unknown.example:8080") })
 	require.NotPanics(t, func() { nilSelector.RecordProxyFailure(ProxySelection{ProxyURL: "http://unknown.example:8080"}) })
+	require.NotPanics(t, func() {
+		nilSelector.RecordProxyCriticalFailure(ProxySelection{ProxyURL: "http://unknown.example:8080"})
+	})
 	require.NotPanics(t, func() { nilSelector.RecordProxySuccess(ProxySelection{ProxyURL: "http://unknown.example:8080"}) })
 	selection, found := nilSelector.SelectionForProxyURL("http://unknown.example:8080")
 	require.False(t, found)
@@ -299,6 +302,7 @@ func TestProxyRotationSelectorNilEmptyAndUnknownBranches(t *testing.T) {
 	selector.RecordFailure("http://unknown.example:8080")
 	selector.RecordSuccess("http://unknown.example:8080")
 	selector.RecordProxyFailure(ProxySelection{})
+	selector.RecordProxyCriticalFailure(ProxySelection{})
 	selector.RecordProxySuccess(ProxySelection{})
 	selector.RecordProxyFailure(ProxySelection{ProxyURL: "http://unknown.example:8080"})
 	selector.RecordProxySuccess(ProxySelection{ProxyURL: "http://unknown.example:8080"})

--- a/crawler/proxy_selection_tracking.go
+++ b/crawler/proxy_selection_tracking.go
@@ -1,0 +1,264 @@
+package crawler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gocolly/colly/v2"
+)
+
+type proxySelectionTrackerContextKey struct{}
+
+type proxySelectionTracker struct {
+	requestID string
+}
+
+type proxySelectionTrackingTransport struct {
+	base http.RoundTripper
+}
+
+var trackedProxySelections sync.Map
+var trackedProxySelectionLinks sync.Map
+var proxySelectionRequestSequence atomic.Uint64
+
+const proxySelectionTrackingHeader = "X-Crawler-Proxy-Tracking"
+const proxySelectionTrackingLinkHeader = "X-Crawler-Proxy-Tracking-Link"
+const proxySelectionCollyContextKey = "crawler_proxy_selection"
+const proxySelectionTrackingLinkContextKey = "crawler_proxy_selection_tracking_link"
+
+func installProxySelectionTracking(collector *colly.Collector, transport *http.Transport, runtimeTransport http.RoundTripper) {
+	if collector == nil || transport == nil || runtimeTransport == nil || transport.Proxy == nil {
+		return
+	}
+	wrapHTTPTransportProxySelector(transport)
+	collector.OnRequest(func(request *colly.Request) {
+		assignProxySelectionTrackingID(request)
+	})
+	collector.OnError(func(response *colly.Response, _ error) {
+		applyTrackedProxySelection(response)
+		clearTrackedProxySelection(response.Request)
+	})
+	collector.OnResponse(func(response *colly.Response) {
+		applyTrackedProxySelection(response)
+		clearTrackedProxySelection(response.Request)
+	})
+	collector.WithTransport(&proxySelectionTrackingTransport{base: runtimeTransport})
+}
+
+func (transport *proxySelectionTrackingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request == nil {
+		return transport.base.RoundTrip(request)
+	}
+	requestID := strings.TrimSpace(request.Header.Get(proxySelectionTrackingHeader))
+	linkID := strings.TrimSpace(request.Header.Get(proxySelectionTrackingLinkHeader))
+	if requestID == "" && linkID == "" {
+		return transport.base.RoundTrip(request)
+	}
+	updatedContext := request.Context()
+	if requestID != "" {
+		tracker := &proxySelectionTracker{requestID: requestID}
+		updatedContext = context.WithValue(updatedContext, proxySelectionTrackerContextKey{}, tracker)
+	}
+	if requestID != "" && linkID != "" {
+		trackedProxySelectionLinks.Store(linkID, requestID)
+	}
+	updatedRequest := request.Clone(updatedContext)
+	updatedRequest.Header.Del(proxySelectionTrackingHeader)
+	updatedRequest.Header.Del(proxySelectionTrackingLinkHeader)
+	return transport.base.RoundTrip(updatedRequest)
+}
+
+func wrapHTTPTransportProxySelector(transport *http.Transport) {
+	if transport == nil || transport.Proxy == nil {
+		return
+	}
+	delegate := transport.Proxy
+	transport.Proxy = func(request *http.Request) (*url.URL, error) {
+		return trackSelectedProxyURL(request, delegate)
+	}
+}
+
+func trackSelectedProxyURL(
+	request *http.Request,
+	delegate func(*http.Request) (*url.URL, error),
+) (*url.URL, error) {
+	if delegate == nil {
+		return nil, nil
+	}
+	if request == nil {
+		return nil, errors.New("crawler: cannot select proxy for nil request")
+	}
+
+	proxyURL, err := delegate(request)
+	if err != nil {
+		return proxyURL, err
+	}
+	if proxyURL == nil {
+		return nil, nil
+	}
+
+	tracker, _ := request.Context().Value(proxySelectionTrackerContextKey{}).(*proxySelectionTracker)
+	if tracker != nil && tracker.requestID != "" {
+		selection, found := SelectedProxySelection(request)
+		if !found {
+			selection = ProxySelection{ProxyURL: proxyURL.String()}
+		}
+		trackedProxySelections.Store(tracker.requestID, selection)
+	}
+	return proxyURL, nil
+}
+
+func assignProxySelectionTrackingID(request *colly.Request) {
+	if request == nil || request.Headers == nil {
+		return
+	}
+	requestID := strings.TrimSpace(request.Headers.Get(proxySelectionTrackingHeader))
+	if requestID == "" {
+		requestID = nextProxySelectionTrackingID()
+		request.Headers.Set(proxySelectionTrackingHeader, requestID)
+	}
+	linkID := ensureProxySelectionTrackingLinkID(request)
+	if linkID != "" {
+		request.Headers.Set(proxySelectionTrackingLinkHeader, linkID)
+	}
+}
+
+func nextProxySelectionTrackingID() string {
+	return strconv.FormatUint(proxySelectionRequestSequence.Add(1), 10)
+}
+
+func applyTrackedProxySelection(response *colly.Response) {
+	if response == nil || response.Request == nil {
+		return
+	}
+	requestID := requestProxySelectionTrackingID(response.Request)
+	if requestID == "" {
+		return
+	}
+	defer clearTrackedProxySelection(response.Request)
+	proxyValue, ok := trackedProxySelections.Load(requestID)
+	if !ok {
+		return
+	}
+	switch trackedSelection := proxyValue.(type) {
+	case ProxySelection:
+		if strings.TrimSpace(trackedSelection.ProxyURL) == "" {
+			return
+		}
+		if response.Request.ProxyURL == "" {
+			response.Request.ProxyURL = trackedSelection.ProxyURL
+		}
+		attachTrackedProxySelection(response.Request, trackedSelection)
+	case string:
+		proxyURL := strings.TrimSpace(trackedSelection)
+		if proxyURL == "" {
+			return
+		}
+		if response.Request.ProxyURL == "" {
+			response.Request.ProxyURL = proxyURL
+		}
+	}
+}
+
+func clearTrackedProxySelection(request *colly.Request) {
+	requestID := requestProxySelectionTrackingID(request)
+	linkID := requestProxySelectionTrackingLinkID(request)
+	if requestID != "" {
+		trackedProxySelections.Delete(requestID)
+	}
+	if linkID != "" {
+		trackedProxySelectionLinks.Delete(linkID)
+		if request != nil && request.Ctx != nil {
+			request.Ctx.Put(proxySelectionTrackingLinkContextKey, "")
+		}
+	}
+	if request == nil || request.Headers == nil {
+		return
+	}
+	request.Headers.Del(proxySelectionTrackingHeader)
+	request.Headers.Del(proxySelectionTrackingLinkHeader)
+}
+
+func requestProxySelectionTrackingID(request *colly.Request) string {
+	if request == nil {
+		return ""
+	}
+	if request.Headers != nil {
+		requestID := strings.TrimSpace(request.Headers.Get(proxySelectionTrackingHeader))
+		if requestID != "" {
+			return requestID
+		}
+	}
+	linkID := requestProxySelectionTrackingLinkID(request)
+	if linkID == "" {
+		return ""
+	}
+	trackedRequestID, ok := trackedProxySelectionLinks.Load(linkID)
+	if !ok {
+		return ""
+	}
+	requestID, ok := trackedRequestID.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(requestID)
+}
+
+func requestProxySelectionTrackingLinkID(request *colly.Request) string {
+	if request == nil {
+		return ""
+	}
+	if request.Ctx != nil {
+		linkID := strings.TrimSpace(request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+		if linkID != "" {
+			return linkID
+		}
+	}
+	if request.Headers == nil {
+		return ""
+	}
+	return strings.TrimSpace(request.Headers.Get(proxySelectionTrackingLinkHeader))
+}
+
+func ensureProxySelectionTrackingLinkID(request *colly.Request) string {
+	if request == nil {
+		return ""
+	}
+	if request.Ctx == nil {
+		request.Ctx = colly.NewContext()
+	}
+	linkID := strings.TrimSpace(request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+	if linkID != "" {
+		return linkID
+	}
+	linkID = nextProxySelectionTrackingID()
+	request.Ctx.Put(proxySelectionTrackingLinkContextKey, linkID)
+	return linkID
+}
+
+func attachTrackedProxySelection(request *colly.Request, selection ProxySelection) {
+	if request == nil {
+		return
+	}
+	if request.Ctx == nil {
+		request.Ctx = colly.NewContext()
+	}
+	request.Ctx.Put(proxySelectionCollyContextKey, selection)
+}
+
+func selectedProxySelectionFromCollyRequest(request *colly.Request) (ProxySelection, bool) {
+	if request == nil || request.Ctx == nil {
+		return ProxySelection{}, false
+	}
+	selection, ok := request.Ctx.GetAny(proxySelectionCollyContextKey).(ProxySelection)
+	if !ok || strings.TrimSpace(selection.ProxyURL) == "" {
+		return ProxySelection{}, false
+	}
+	return selection, true
+}

--- a/crawler/proxy_selection_tracking.go
+++ b/crawler/proxy_selection_tracking.go
@@ -69,9 +69,26 @@ func (transport *proxySelectionTrackingTransport) RoundTrip(request *http.Reques
 		trackedProxySelectionLinks.Store(linkID, requestID)
 	}
 	updatedRequest := request.Clone(updatedContext)
+	attachStoredProxySelection(updatedRequest, requestID)
 	updatedRequest.Header.Del(proxySelectionTrackingHeader)
 	updatedRequest.Header.Del(proxySelectionTrackingLinkHeader)
 	return transport.base.RoundTrip(updatedRequest)
+}
+
+func attachStoredProxySelection(request *http.Request, requestID string) {
+	if request == nil || strings.TrimSpace(requestID) == "" {
+		return
+	}
+	storedSelection, found := trackedProxySelections.Load(strings.TrimSpace(requestID))
+	if !found {
+		return
+	}
+	switch selection := storedSelection.(type) {
+	case ProxySelection:
+		AttachProxySelection(request, selection)
+	case string:
+		AttachProxySelection(request, ProxySelection{ProxyURL: strings.TrimSpace(selection)})
+	}
 }
 
 func wrapHTTPTransportProxySelector(transport *http.Transport) {

--- a/crawler/proxy_selection_tracking_test.go
+++ b/crawler/proxy_selection_tracking_test.go
@@ -1,0 +1,301 @@
+package crawler
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gocolly/colly/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type proxyTrackingRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn proxyTrackingRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestInstallProxySelectionTrackingAnnotatesCollyResponses(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://provider-one.example:8080",
+		}},
+	}})
+	require.NoError(t, err)
+
+	transport := &http.Transport{Proxy: selector.Select}
+	runtimeTransport := proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		proxyURL, proxyErr := transport.Proxy(request)
+		require.NoError(t, proxyErr)
+		require.Equal(t, "http://provider-one.example:8080", proxyURL.String())
+		require.Empty(t, request.Header.Get(proxySelectionTrackingHeader))
+		require.Empty(t, request.Header.Get(proxySelectionTrackingLinkHeader))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/html"}},
+			Body:       io.NopCloser(strings.NewReader("<html><head><title>ok</title></head></html>")),
+			Request:    request,
+		}, nil
+	})
+	collector := colly.NewCollector(colly.AllowURLRevisit())
+	installProxySelectionTracking(collector, transport, runtimeTransport)
+
+	var responseSelection ProxySelection
+	var foundSelection bool
+	collector.OnResponse(func(response *colly.Response) {
+		responseSelection, foundSelection = selectedProxySelectionFromResponse(response)
+	})
+
+	err = collector.Request(http.MethodGet, "http://example.com/product", nil, colly.NewContext(), nil)
+	require.NoError(t, err)
+	collector.Wait()
+
+	require.True(t, foundSelection)
+	require.Equal(t, "provider-one", responseSelection.ProviderName)
+	require.Equal(t, "user-one", responseSelection.UserName)
+	require.Equal(t, "http://provider-one.example:8080", responseSelection.ProxyURL)
+}
+
+func TestInstallProxySelectionTrackingAnnotatesCollyErrors(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://provider-one.example:8080",
+		}},
+	}})
+	require.NoError(t, err)
+
+	transport := &http.Transport{Proxy: selector.Select}
+	runtimeTransport := proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		_, proxyErr := transport.Proxy(request)
+		require.NoError(t, proxyErr)
+		return nil, errors.New("request failed")
+	})
+	collector := colly.NewCollector(colly.AllowURLRevisit())
+	installProxySelectionTracking(collector, transport, runtimeTransport)
+
+	var errorSelection ProxySelection
+	var foundSelection bool
+	collector.OnError(func(response *colly.Response, _ error) {
+		errorSelection, foundSelection = selectedProxySelectionFromResponse(response)
+	})
+
+	err = collector.Request(http.MethodGet, "http://example.com/product", nil, colly.NewContext(), nil)
+	require.ErrorContains(t, err, "request failed")
+	collector.Wait()
+
+	require.True(t, foundSelection)
+	require.Equal(t, "provider-one", errorSelection.ProviderName)
+	require.Equal(t, "http://provider-one.example:8080", errorSelection.ProxyURL)
+}
+
+func TestProxySelectionTrackingBoundaryBranches(t *testing.T) {
+	installProxySelectionTracking(nil, nil, nil)
+	installProxySelectionTracking(colly.NewCollector(), nil, proxyTrackingRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+	installProxySelectionTracking(colly.NewCollector(), &http.Transport{}, nil)
+	installProxySelectionTracking(colly.NewCollector(), &http.Transport{}, proxyTrackingRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+
+	transport := &proxySelectionTrackingTransport{base: proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request != nil {
+			require.Empty(t, request.Header.Get(proxySelectionTrackingHeader))
+			require.Empty(t, request.Header.Get(proxySelectionTrackingLinkHeader))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    request,
+		}, nil
+	})}
+
+	response, err := transport.RoundTrip(nil)
+	require.NoError(t, err)
+	require.Nil(t, response.Request)
+
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	response, err = transport.RoundTrip(request)
+	require.NoError(t, err)
+	require.Same(t, request, response.Request)
+
+	request.Header.Set(proxySelectionTrackingHeader, "request-one")
+	request.Header.Set(proxySelectionTrackingLinkHeader, "link-one")
+	response, err = transport.RoundTrip(request)
+	require.NoError(t, err)
+	require.NotSame(t, request, response.Request)
+	require.Equal(t, "request-one", response.Request.Context().Value(proxySelectionTrackerContextKey{}).(*proxySelectionTracker).requestID)
+	trackedRequestID, found := trackedProxySelectionLinks.Load("link-one")
+	require.True(t, found)
+	require.Equal(t, "request-one", trackedRequestID)
+}
+
+func TestTrackSelectedProxyURLBoundaryBranches(t *testing.T) {
+	wrapHTTPTransportProxySelector(nil)
+	wrapHTTPTransportProxySelector(&http.Transport{})
+
+	proxyURL, err := trackSelectedProxyURL(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, proxyURL)
+
+	proxyURL, err = trackSelectedProxyURL(nil, func(*http.Request) (*url.URL, error) {
+		return nil, nil
+	})
+	require.ErrorContains(t, err, "nil request")
+	require.Nil(t, proxyURL)
+
+	expectedErr := errors.New("select failed")
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	proxyURL, err = trackSelectedProxyURL(request, func(*http.Request) (*url.URL, error) {
+		parsedProxyURL, parseErr := url.Parse("http://proxy.example:8080")
+		require.NoError(t, parseErr)
+		return parsedProxyURL, expectedErr
+	})
+	require.ErrorIs(t, err, expectedErr)
+	require.Equal(t, "http://proxy.example:8080", proxyURL.String())
+
+	proxyURL, err = trackSelectedProxyURL(request, func(*http.Request) (*url.URL, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, proxyURL)
+
+	proxyURL, err = trackSelectedProxyURL(request, func(*http.Request) (*url.URL, error) {
+		return url.Parse("http://proxy.example:8080")
+	})
+	require.NoError(t, err)
+	require.Equal(t, "http://proxy.example:8080", proxyURL.String())
+
+	trackedRequest, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	trackedRequest = trackedRequest.WithContext(context.WithValue(
+		trackedRequest.Context(),
+		proxySelectionTrackerContextKey{},
+		&proxySelectionTracker{requestID: "fallback-selection"},
+	))
+	proxyURL, err = trackSelectedProxyURL(trackedRequest, func(*http.Request) (*url.URL, error) {
+		return url.Parse("http://fallback-proxy.example:8080")
+	})
+	require.NoError(t, err)
+	require.Equal(t, "http://fallback-proxy.example:8080", proxyURL.String())
+	storedSelection, found := trackedProxySelections.Load("fallback-selection")
+	require.True(t, found)
+	require.Equal(t, "http://fallback-proxy.example:8080", storedSelection.(ProxySelection).ProxyURL)
+}
+
+func TestApplyTrackedProxySelectionBoundaryBranches(t *testing.T) {
+	applyTrackedProxySelection(nil)
+	applyTrackedProxySelection(&colly.Response{})
+
+	headers := http.Header{}
+	request := &colly.Request{Headers: &headers, Ctx: colly.NewContext()}
+	applyTrackedProxySelection(&colly.Response{Request: request})
+
+	headers.Set(proxySelectionTrackingHeader, "missing")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Empty(t, request.ProxyURL)
+
+	trackedProxySelections.Store("empty-selection", ProxySelection{})
+	headers.Set(proxySelectionTrackingHeader, "empty-selection")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Empty(t, request.ProxyURL)
+
+	trackedProxySelections.Store("empty-string", "")
+	headers.Set(proxySelectionTrackingHeader, "empty-string")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Empty(t, request.ProxyURL)
+
+	trackedProxySelections.Store("string-selection", "http://string-proxy.example:8080")
+	headers.Set(proxySelectionTrackingHeader, "string-selection")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Equal(t, "http://string-proxy.example:8080", request.ProxyURL)
+
+	request.ProxyURL = "http://existing-proxy.example:8080"
+	trackedProxySelections.Store("lease-selection", ProxySelection{
+		ProviderName: "provider-one",
+		UserName:     "user-one",
+		ProxyURL:     "http://lease-proxy.example:8080",
+	})
+	headers.Set(proxySelectionTrackingHeader, "lease-selection")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Equal(t, "http://existing-proxy.example:8080", request.ProxyURL)
+	selection, found := selectedProxySelectionFromCollyRequest(request)
+	require.True(t, found)
+	require.Equal(t, "http://lease-proxy.example:8080", selection.ProxyURL)
+}
+
+func TestProxySelectionTrackingIDAndLinkBranches(t *testing.T) {
+	assignProxySelectionTrackingID(nil)
+	assignProxySelectionTrackingID(&colly.Request{})
+
+	headers := http.Header{}
+	request := &colly.Request{Headers: &headers}
+	assignProxySelectionTrackingID(request)
+	require.NotEmpty(t, headers.Get(proxySelectionTrackingHeader))
+	require.NotEmpty(t, headers.Get(proxySelectionTrackingLinkHeader))
+	require.NotEmpty(t, request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+
+	linkID := request.Ctx.Get(proxySelectionTrackingLinkContextKey)
+	headers.Del(proxySelectionTrackingHeader)
+	trackedProxySelectionLinks.Store(linkID, 42)
+	require.Empty(t, requestProxySelectionTrackingID(request))
+
+	trackedProxySelectionLinks.Store(linkID, " linked-request ")
+	require.Equal(t, "linked-request", requestProxySelectionTrackingID(request))
+	require.Equal(t, linkID, requestProxySelectionTrackingLinkID(request))
+
+	clearTrackedProxySelection(request)
+	require.Empty(t, request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+	require.Empty(t, headers.Get(proxySelectionTrackingHeader))
+	require.Empty(t, headers.Get(proxySelectionTrackingLinkHeader))
+	clearTrackedProxySelection(nil)
+
+	require.Empty(t, requestProxySelectionTrackingID(nil))
+	require.Empty(t, requestProxySelectionTrackingLinkID(nil))
+	require.Empty(t, requestProxySelectionTrackingLinkID(&colly.Request{}))
+	require.Empty(t, ensureProxySelectionTrackingLinkID(nil))
+
+	requestWithoutHeaders := &colly.Request{Ctx: colly.NewContext()}
+	requestWithoutHeaders.Ctx.Put(proxySelectionTrackingLinkContextKey, "ctx-link")
+	require.Empty(t, requestProxySelectionTrackingID(requestWithoutHeaders))
+	trackedProxySelectionLinks.Store("ctx-link", "ctx-request")
+	require.Equal(t, "ctx-request", requestProxySelectionTrackingID(requestWithoutHeaders))
+
+	require.Equal(t, "ctx-link", ensureProxySelectionTrackingLinkID(requestWithoutHeaders))
+
+	directHeaderRequest := &colly.Request{Headers: &http.Header{}}
+	directHeaderRequest.Headers.Set(proxySelectionTrackingHeader, "direct-request")
+	require.Equal(t, "direct-request", requestProxySelectionTrackingID(directHeaderRequest))
+
+	require.Empty(t, requestProxySelectionTrackingID(&colly.Request{}))
+}
+
+func TestAttachAndReadTrackedProxySelectionBoundaryBranches(t *testing.T) {
+	attachTrackedProxySelection(nil, ProxySelection{ProxyURL: "http://proxy.example:8080"})
+	request := &colly.Request{}
+	attachTrackedProxySelection(request, ProxySelection{ProxyURL: "http://proxy.example:8080"})
+	selection, found := selectedProxySelectionFromCollyRequest(request)
+	require.True(t, found)
+	require.Equal(t, "http://proxy.example:8080", selection.ProxyURL)
+
+	selection, found = selectedProxySelectionFromCollyRequest(nil)
+	require.False(t, found)
+	require.Empty(t, selection)
+	selection, found = selectedProxySelectionFromCollyRequest(&colly.Request{Ctx: colly.NewContext()})
+	require.False(t, found)
+	require.Empty(t, selection)
+	selection, found = selectedProxySelectionFromResponse(nil)
+	require.False(t, found)
+	require.Empty(t, selection)
+}

--- a/crawler/proxy_selection_tracking_test.go
+++ b/crawler/proxy_selection_tracking_test.go
@@ -140,6 +140,54 @@ func TestProxySelectionTrackingBoundaryBranches(t *testing.T) {
 	require.Equal(t, "request-one", trackedRequestID)
 }
 
+func TestProxySelectionTrackingTransportAttachesStoredSelection(t *testing.T) {
+	storedSelection := ProxySelection{
+		ProviderName: "provider-one",
+		UserName:     "user-one",
+		ProxyURL:     "http://provider-one.example:8080",
+		Generation:   3,
+	}
+	trackedProxySelections.Store("request-one", storedSelection)
+	defer trackedProxySelections.Delete("request-one")
+
+	transport := &proxySelectionTrackingTransport{base: proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		selection, found := SelectedProxySelection(request)
+		require.True(t, found)
+		require.Equal(t, storedSelection, selection)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    request,
+		}, nil
+	})}
+
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	request.Header.Set(proxySelectionTrackingHeader, "request-one")
+
+	response, err := transport.RoundTrip(request)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+}
+
+func TestAttachStoredProxySelectionBoundaryBranches(t *testing.T) {
+	attachStoredProxySelection(nil, "request-one")
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	attachStoredProxySelection(request, " ")
+	attachStoredProxySelection(request, "missing")
+	_, found := SelectedProxySelection(request)
+	require.False(t, found)
+
+	trackedProxySelections.Store("string-request", " http://string-proxy.example:8080 ")
+	defer trackedProxySelections.Delete("string-request")
+	attachStoredProxySelection(request, "string-request")
+	selection, found := SelectedProxySelection(request)
+	require.True(t, found)
+	require.Equal(t, "http://string-proxy.example:8080", selection.ProxyURL)
+}
+
 func TestTrackSelectedProxyURLBoundaryBranches(t *testing.T) {
 	wrapHTTPTransportProxySelector(nil)
 	wrapHTTPTransportProxySelector(&http.Transport{})

--- a/crawler/response.go
+++ b/crawler/response.go
@@ -215,6 +215,12 @@ func (processor *responseProcessor) recordProxySuccess(resp *colly.Response) {
 	if processor.proxyTracker == nil || proxyURL == "" {
 		return
 	}
+	if lease, found := selectedProxySelectionFromResponse(resp); found {
+		if reporter, ok := processor.proxyTracker.(proxyLeaseReporter); ok {
+			reporter.ReportSuccess(lease)
+			return
+		}
+	}
 	processor.proxyTracker.RecordSuccess(proxyURL)
 }
 
@@ -237,16 +243,23 @@ func (processor *responseProcessor) retryByDecision(resp *colly.Response, decisi
 }
 
 func (processor *responseProcessor) alternativeProxyRetryCount() int {
-	if len(processor.scraperConfig.ProxyList) <= 1 {
+	proxyCandidateCount := processor.scraperConfig.ProxyCandidateCount()
+	if proxyCandidateCount <= 1 {
 		return 0
 	}
-	return len(processor.scraperConfig.ProxyList) - 1
+	return proxyCandidateCount - 1
 }
 
 func (processor *responseProcessor) recordCriticalProxyFailure(resp *colly.Response) {
 	proxyURL := responseProxyURL(resp)
 	if processor.proxyTracker == nil || proxyURL == "" {
 		return
+	}
+	if lease, found := selectedProxySelectionFromResponse(resp); found {
+		if reporter, ok := processor.proxyTracker.(proxyLeaseReporter); ok {
+			reporter.ReportCriticalFailure(lease)
+			return
+		}
 	}
 	processor.proxyTracker.RecordCriticalFailure(proxyURL)
 }
@@ -256,6 +269,13 @@ func responseProxyURL(resp *colly.Response) string {
 		return ""
 	}
 	return strings.TrimSpace(resp.Request.ProxyURL)
+}
+
+func selectedProxySelectionFromResponse(resp *colly.Response) (ProxySelection, bool) {
+	if resp == nil {
+		return ProxySelection{}, false
+	}
+	return selectedProxySelectionFromCollyRequest(resp.Request)
 }
 
 func (processor *responseProcessor) inferRedirect(productID, originalURL, finalURL, canonicalURL string, ctx *colly.Context) {

--- a/crawler/retry.go
+++ b/crawler/retry.go
@@ -30,7 +30,7 @@ func newRetryHandler(scraper ScraperConfig, logger Logger) RetryHandler {
 	return &retryHandler{
 		maxRetries:    scraper.RetryCount,
 		logger:        logger,
-		proxyPoolSize: len(scraper.ProxyList),
+		proxyPoolSize: scraper.ProxyCandidateCount(),
 		sleepFn:       time.Sleep,
 	}
 }

--- a/crawler/service.go
+++ b/crawler/service.go
@@ -337,6 +337,11 @@ func recordProxyFailure(tracker proxyHealth, resp *colly.Response) {
 		return
 	}
 	if !shouldRecordProxyFailure(resp.StatusCode) {
+		if lease, found := selectedProxySelectionFromResponse(resp); found {
+			if releaser, ok := tracker.(proxyLeaseReleaser); ok {
+				releaser.Release(lease)
+			}
+		}
 		return
 	}
 	if lease, found := selectedProxySelectionFromResponse(resp); found {

--- a/crawler/service.go
+++ b/crawler/service.go
@@ -73,10 +73,6 @@ func NewService(cfg Config, results chan<- *Result, options ...ServiceOption) (*
 
 	responseProcessor := newResponseProcessor(cfg, retryHandler, proxyTracker, filePersister, results, logger)
 
-	requestConfigurator.Configure(collector)
-	setupErrorHandling(collector, responseProcessor, retryHandler, proxyTracker, logger)
-	responseProcessor.Setup(collector)
-
 	service := &Service{
 		config:              cfg,
 		collector:           collector,
@@ -95,6 +91,7 @@ func NewService(cfg Config, results chan<- *Result, options ...ServiceOption) (*
 		option(service)
 	}
 
+	requestConfigurator.Configure(collector)
 	bindResponseHandlersRuntime(service.responseHandlers, collector, filePersister, retryHandler)
 	responseProcessor.SetResultCallback(service.releaseProductSlot)
 	responseProcessor.SetResponseHandlers(service.responseHandlers)
@@ -102,7 +99,11 @@ func NewService(cfg Config, results chan<- *Result, options ...ServiceOption) (*
 	contextTransport := newContextAwareTransport(transport, service.currentRunContext)
 	panicSafeTransport := newPanicSafeTransport(contextTransport, logger)
 	collector.WithTransport(panicSafeTransport)
+	httpTransport, _ := transport.(*http.Transport)
+	installProxySelectionTracking(collector, httpTransport, panicSafeTransport)
 
+	setupErrorHandling(collector, responseProcessor, retryHandler, proxyTracker, logger)
+	responseProcessor.Setup(collector)
 	service.serviceHook.AfterInit(collector, panicSafeTransport)
 
 	return service, nil
@@ -216,30 +217,53 @@ func newCollector(cfg Config, logger Logger) (*colly.Collector, proxyHealth, htt
 
 	_ = webCollector.Limit(limitRule)
 
-	var tracker proxyHealth
-	proxyHealthEnabled := cfg.Scraper.ProxyCircuitBreakerEnabled
-	switch len(cfg.Scraper.ProxyList) {
-	case 0:
-	case 1:
-		proxyFn, err := newProxyRotator(cfg.Scraper.ProxyList, nil, logger)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		webCollector.SetProxyFunc(proxyFn)
-	default:
-		if proxyHealthEnabled {
-			tracker = newProxyHealthTracker(cfg.Scraper.ProxyList, logger)
-		}
-		proxyFn, err := newProxyRotator(cfg.Scraper.ProxyList, tracker, logger)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		webCollector.SetProxyFunc(proxyFn)
+	proxySelector, err := proxyLeaseSelectorForScraper(cfg.Scraper, logger)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if proxySelector != nil {
+		webCollector.SetProxyFunc(proxySelector.Select)
 	}
 
 	cookieJar, _ := cookiejar.New(nil)
 	webCollector.SetCookieJar(cookieJar)
-	return webCollector, tracker, transport, nil
+	return webCollector, proxySelector, transport, nil
+}
+
+func proxyLeaseSelectorForScraper(scraper ScraperConfig, logger Logger) (*ProxyLeaseSelector, error) {
+	if scraper.ProxyLeaseSelector != nil {
+		return scraper.ProxyLeaseSelector, nil
+	}
+	if len(scraper.ProxyList) == 0 {
+		return nil, nil
+	}
+	providers := []ProxyRotationProviderConfig{{
+		Name:  "flat",
+		Users: proxyUsersFromFlatList(scraper.ProxyList),
+	}}
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		providers,
+		ProxyLeaseSelectorCircuitBreaker(scraper.ProxyCircuitBreakerEnabled),
+		ProxyLeaseSelectorLogger(logger),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("crawler: build proxy selector: %w", err)
+	}
+	if selector == nil {
+		return nil, fmt.Errorf("%w: proxy list is empty", ErrProxyLeaseUnavailable)
+	}
+	return selector, nil
+}
+
+func proxyUsersFromFlatList(proxyURLs []string) []ProxyRotationUserConfig {
+	users := make([]ProxyRotationUserConfig, 0, len(proxyURLs))
+	for index, proxyURL := range proxyURLs {
+		users = append(users, ProxyRotationUserConfig{
+			Name: fmt.Sprintf("proxy-%d", index+1),
+			URL:  proxyURL,
+		})
+	}
+	return users
 }
 
 func shouldOverrideCollectorRequestTimeout(timeout time.Duration) bool {
@@ -312,10 +336,25 @@ func recordProxyFailure(tracker proxyHealth, resp *colly.Response) {
 	if resp.Request.ProxyURL == "" {
 		return
 	}
-	if resp.StatusCode != 0 {
+	if !shouldRecordProxyFailure(resp.StatusCode) {
 		return
 	}
+	if lease, found := selectedProxySelectionFromResponse(resp); found {
+		if reporter, ok := tracker.(proxyLeaseReporter); ok {
+			reporter.ReportFailure(lease)
+			return
+		}
+	}
 	tracker.RecordFailure(resp.Request.ProxyURL)
+}
+
+func shouldRecordProxyFailure(statusCode int) bool {
+	switch statusCode {
+	case 0, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 func (service *Service) reserveProductSlot(ctx context.Context, productID string) error {

--- a/crawler/service_integration_test.go
+++ b/crawler/service_integration_test.go
@@ -219,6 +219,38 @@ func TestNewCollectorSingleProxyAnnotatesRequestContext(t *testing.T) {
 	require.Equal(t, "http://user:pass@proxy-one.test:8080", req.Context().Value(colly.ProxyURLKey))
 }
 
+func TestProxyLeaseSelectorForScraperUsesInjectedSelector(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://proxy.example:8080",
+		}},
+	}})
+	require.NoError(t, err)
+
+	resolvedSelector, err := proxyLeaseSelectorForScraper(ScraperConfig{
+		ProxyLeaseSelector: selector,
+		ProxyList:          []string{"://bad"},
+	}, noopLogger{})
+	require.NoError(t, err)
+	require.Same(t, selector, resolvedSelector)
+}
+
+func TestProxyLeaseSelectorForScraperHandlesEmptyAndBlankLists(t *testing.T) {
+	t.Parallel()
+
+	selector, err := proxyLeaseSelectorForScraper(ScraperConfig{}, noopLogger{})
+	require.NoError(t, err)
+	require.Nil(t, selector)
+
+	selector, err = proxyLeaseSelectorForScraper(ScraperConfig{ProxyList: []string{" "}}, noopLogger{})
+	require.ErrorIs(t, err, ErrProxyLeaseUnavailable)
+	require.Nil(t, selector)
+}
+
 func TestNewServiceBindsRuntimeToResponseHandlers(t *testing.T) {
 	t.Parallel()
 
@@ -298,6 +330,55 @@ func TestErrorHandlingCountsProxyConnectionFailures(t *testing.T) {
 	require.Equal(t, []string{"http://failing-proxy"}, tracker.failures)
 	require.Len(t, processor.results, 1)
 	require.Equal(t, 0, processor.results[0].statusCode)
+}
+
+func TestProxySelectionTrackingPreservesSelectedLeaseGeneration(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{
+		{
+			Name: "provider-one",
+			Users: []ProxyRotationUserConfig{
+				{Name: "user-one", URL: "http://provider-one.example:8080"},
+			},
+		},
+		{
+			Name: "provider-two",
+			Users: []ProxyRotationUserConfig{
+				{Name: "user-one", URL: "http://provider-two.example:8080"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	httpRequest, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	httpRequest = httpRequest.WithContext(context.WithValue(
+		httpRequest.Context(),
+		proxySelectionTrackerContextKey{},
+		&proxySelectionTracker{requestID: "request-one"},
+	))
+
+	_, err = trackSelectedProxyURL(httpRequest, selector.Select)
+	require.NoError(t, err)
+	initialLease, found := SelectedProxySelection(httpRequest)
+	require.True(t, found)
+
+	selector.ReportFailure(initialLease)
+	require.NotEqual(t, initialLease.Generation, selector.Acquire().Generation)
+
+	headers := http.Header{}
+	headers.Set(proxySelectionTrackingHeader, "request-one")
+	response := &colly.Response{
+		StatusCode: 0,
+		Request: &colly.Request{
+			Headers: &headers,
+			Ctx:     colly.NewContext(),
+		},
+	}
+
+	applyTrackedProxySelection(response)
+	trackedLease, found := selectedProxySelectionFromResponse(response)
+	require.True(t, found)
+	require.Equal(t, initialLease, trackedLease)
 }
 
 func TestHandleCollectorErrorHandlesNilResponse(t *testing.T) {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -51,6 +51,18 @@ Unlike Client.Chat, Factory.Chat assumes the caller passes a non-nil context and
 
 Chat marshals the request payload directly with json.Marshal even when ResponseFormat.Schema contains malformed JSON; json.RawMessage does not validate its contents, so json.Marshal succeeds and the client proceeds to POST an invalid body, returning a transport/HTTP error instead of failing fast with an encoding error (e.g., the schema used in TestClientChatFailsWhenMarshallingRequestPayload). This lets malformed response formats slip through and results in requests the API will reject.
 
+- [x] [UT-307] Allow lease reuse when all proxies are currently reserved. (Return the least-reserved healthy proxy instead of exhausting candidates when concurrent in-flight requests exceed the configured proxy count.)
+
+Returning an empty lease when every configured proxy is reserved makes `acquire()` emit `ErrProxyLeaseCandidatesExhausted`, which bubbles through `Select` into HTTP transport proxy callbacks and fails requests even though healthy proxies exist.
+
+Resolved: `ProxyLeaseSelector` now falls back to the least-reserved healthy lease after all unreserved candidates are occupied, while cooldown-unavailable candidates remain skipped. Added regression coverage for saturated public `Select` behavior and updated lease-selector expectations/docs/changelog. Changed files: `crawler/proxy_rotation_selector.go`, `crawler/proxy_lease_selector_test.go`, `README.md`, `ARCHITECTURE.md`, `CHANGELOG.md`, `issues.md/ISSUES.md`. Verified with `timeout -k 350s -s SIGKILL 350s make test`, `timeout -k 350s -s SIGKILL 350s make lint`, and `timeout -k 350s -s SIGKILL 350s make ci`.
+
+- [x] [UT-308] Reject trailing YAML documents after strict decode. (Require strict config loads to fail when a YAML stream contains more than one document instead of silently accepting only the first document.)
+
+The strict config loader performs one YAML decode and returns success without requiring the next decode to be `io.EOF`, so later YAML documents can be ignored while operators believe those settings were applied.
+
+Resolved: `configfile` now decodes exactly one YAML document before interpolation and requires EOF after the strict `KnownFields(true)` decode. Added `LoadYAMLBytes` and interpolation regressions for trailing documents, malformed trailing documents, and the final strict-decode EOF check; updated configfile docs/changelog. Changed files: `configfile/configfile.go`, `configfile/configfile_test.go`, `README.md`, `ARCHITECTURE.md`, `CHANGELOG.md`, `issues.md/ISSUES.md`. Verified with `timeout -k 350s -s SIGKILL 350s make test`, `timeout -k 350s -s SIGKILL 350s make lint`, and `timeout -k 350s -s SIGKILL 350s make ci`.
+
 ## Maintenance (407–449)
 
 - [x] [UT-410] Extract a shared browser transport runtime beneath jseval. (Add `browsertransport` with transport profiles, reusable sessions, SOCKS forwarding, HTTP client helpers, and one-shot rendering; make `jseval` a compatibility wrapper with migrated coverage.)


### PR DESCRIPTION
## Summary
- Add new `configfile` package with strict YAML loading and interpolation helpers.
- Document new package in `ARCHITECTURE.md` and `README.md`.
- Cover behavior with unit tests in `configfile/configfile_test.go`.

## Scope
- `LoadYAML` reads and validates file path, parses YAML, and decodes with strict known fields.
- `LoadYAMLBytes` validates the target, expands interpolations, and decodes.
- `InterpolateYAML` performs scalar-only env interpolation with missing variable detection and invalid syntax rejection.
- Added typed errors for parse/read/validation paths.

## Notes
- Local validation/tests were not run in this handoff.
