### PR TITLE
Unify crawler proxy lease rotation

### DIFF
--- a/crawler/config.go
+++ b/crawler/config.go
@@ -75,8 +75,17 @@ type ScraperConfig struct {
 	InsecureSkipVerify         bool
 	RateLimit                  time.Duration
 	ProxyList                  []string
+	ProxyLeaseSelector         *ProxyLeaseSelector
 	SaveFiles                  bool
 	ProxyCircuitBreakerEnabled bool
+}
+
+// ProxyCandidateCount reports the configured proxy candidate count.
+func (cfg ScraperConfig) ProxyCandidateCount() int {
+	if cfg.ProxyLeaseSelector != nil {
+		return cfg.ProxyLeaseSelector.CandidateCount()
+	}
+	return len(cfg.ProxyList)
 }
 
 // Validate checks that essential numeric fields are positive.

--- a/crawler/coverage_test.go
+++ b/crawler/coverage_test.go
@@ -1513,6 +1513,34 @@ func TestRecordProxyFailureNonZeroStatusCode(t *testing.T) {
 	require.Empty(t, tracker.failures)
 }
 
+func TestRecordProxyFailureNeutralStatusReleasesTrackedLease(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://proxy-one:8080"},
+			{Name: "user-two", URL: "http://proxy-two:8080"},
+		},
+	}})
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	resp := &colly.Response{
+		StatusCode: http.StatusNotFound,
+		Request: &colly.Request{
+			ProxyURL: lease.ProxyURL,
+			Ctx:      colly.NewContext(),
+		},
+	}
+	attachTrackedProxySelection(resp.Request, lease)
+
+	recordProxyFailure(selector, resp)
+
+	nextLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, lease.ProxyURL, nextLease.ProxyURL)
+}
+
 func TestRecordProxyFailureBadGatewayStatusCode(t *testing.T) {
 	tracker := &trackingProxyHealth{}
 	resp := &colly.Response{

--- a/crawler/coverage_test.go
+++ b/crawler/coverage_test.go
@@ -699,6 +699,29 @@ func TestRecordProxySuccessWithTracker(t *testing.T) {
 	require.Equal(t, []string{"http://proxy:8080"}, tracker.successes)
 }
 
+func TestRecordProxySuccessWithLeaseReporter(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://proxy:8080",
+		}},
+	}})
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	processor := &responseProcessor{proxyTracker: selector}
+	resp := newTestResponse("PROD")
+	resp.Request.ProxyURL = lease.ProxyURL
+	attachTrackedProxySelection(resp.Request, lease)
+
+	processor.recordProxySuccess(resp)
+	reusedLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, lease.ProxyURL, reusedLease.ProxyURL)
+}
+
 func TestRecordProxySuccessNoTracker(t *testing.T) {
 	processor := &responseProcessor{}
 	resp := newTestResponse("PROD")
@@ -712,6 +735,44 @@ func TestRecordProxySuccessEmptyProxyURL(t *testing.T) {
 	resp := newTestResponse("PROD")
 	processor.recordProxySuccess(resp)
 	require.Empty(t, tracker.successes)
+}
+
+func TestRecordCriticalProxyFailureWithLeaseReporter(t *testing.T) {
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{{
+			Name: "provider-one",
+			Users: []ProxyRotationUserConfig{{
+				Name: "user-one",
+				URL:  "http://proxy:8080",
+			}},
+		}},
+		ProxyLeaseSelectorCircuitBreaker(true),
+		ProxyLeaseSelectorClock(func() time.Time { return time.Unix(0, 0) }),
+	)
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	processor := &responseProcessor{proxyTracker: selector}
+	resp := newTestResponse("PROD")
+	resp.Request.ProxyURL = lease.ProxyURL
+	attachTrackedProxySelection(resp.Request, lease)
+
+	processor.recordCriticalProxyFailure(resp)
+	require.False(t, selector.IsAvailable(lease.ProxyURL))
+}
+
+func TestRecordCriticalProxyFailureBoundaryBranches(t *testing.T) {
+	processor := &responseProcessor{}
+	resp := newTestResponse("PROD")
+	resp.Request.ProxyURL = "http://proxy:8080"
+	require.NotPanics(t, func() { processor.recordCriticalProxyFailure(resp) })
+
+	tracker := &trackingProxyHealth{}
+	processor = &responseProcessor{proxyTracker: tracker}
+	resp.Request.ProxyURL = ""
+	processor.recordCriticalProxyFailure(resp)
+	require.Empty(t, tracker.criticalFailures)
 }
 
 func TestRetryByDecisionNilHandler(t *testing.T) {
@@ -1445,11 +1506,48 @@ func TestRecordProxyFailureEmptyProxyURL(t *testing.T) {
 func TestRecordProxyFailureNonZeroStatusCode(t *testing.T) {
 	tracker := &trackingProxyHealth{}
 	resp := &colly.Response{
-		StatusCode: http.StatusBadGateway,
+		StatusCode: http.StatusBadRequest,
 		Request:    &colly.Request{ProxyURL: "http://proxy:8080"},
 	}
 	recordProxyFailure(tracker, resp)
 	require.Empty(t, tracker.failures)
+}
+
+func TestRecordProxyFailureBadGatewayStatusCode(t *testing.T) {
+	tracker := &trackingProxyHealth{}
+	resp := &colly.Response{
+		StatusCode: http.StatusBadGateway,
+		Request:    &colly.Request{ProxyURL: "http://proxy:8080"},
+	}
+	recordProxyFailure(tracker, resp)
+	require.Equal(t, []string{"http://proxy:8080"}, tracker.failures)
+}
+
+func TestRecordProxyFailureWithLeaseReporter(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://proxy-one:8080"},
+			{Name: "user-two", URL: "http://proxy-two:8080"},
+		},
+	}})
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	resp := &colly.Response{
+		StatusCode: 0,
+		Request: &colly.Request{
+			ProxyURL: lease.ProxyURL,
+			Ctx:      colly.NewContext(),
+		},
+	}
+	attachTrackedProxySelection(resp.Request, lease)
+
+	recordProxyFailure(selector, resp)
+	nextLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://proxy-two:8080", nextLease.ProxyURL)
 }
 
 // ─── NewService with proxies and circuit breaker ──────────────────────────

--- a/crawler/proxy_health.go
+++ b/crawler/proxy_health.go
@@ -18,6 +18,10 @@ type proxyLeaseReporter interface {
 	ReportCriticalFailure(lease ProxyLease)
 }
 
+type proxyLeaseReleaser interface {
+	Release(lease ProxyLease)
+}
+
 type proxyHealthTracker struct {
 	logger           Logger
 	mu               sync.Mutex

--- a/crawler/proxy_health.go
+++ b/crawler/proxy_health.go
@@ -12,6 +12,12 @@ type proxyHealth interface {
 	RecordCriticalFailure(proxy string)
 }
 
+type proxyLeaseReporter interface {
+	ReportSuccess(lease ProxyLease)
+	ReportFailure(lease ProxyLease)
+	ReportCriticalFailure(lease ProxyLease)
+}
+
 type proxyHealthTracker struct {
 	logger           Logger
 	mu               sync.Mutex

--- a/crawler/proxy_lease_selector_test.go
+++ b/crawler/proxy_lease_selector_test.go
@@ -44,6 +44,33 @@ func TestProxyLeaseSelectorAcquiresDistinctLeasesAndReusesReleasedSuccess(t *tes
 	require.Equal(t, firstLease.ProxyURL, reusedLease.ProxyURL)
 }
 
+func TestProxyLeaseSelectorAcquireForRequestReusesAttachedLease(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://provider-one-user-one.example:8080"},
+			{Name: "user-two", URL: "http://provider-one-user-two.example:8080"},
+		},
+	}})
+	require.NoError(t, err)
+	request, err := http.NewRequest(http.MethodGet, "https://example.com/product", nil)
+	require.NoError(t, err)
+	firstLease, err := selector.AcquireForRequest(request)
+	require.NoError(t, err)
+
+	redirectRequest := request.Clone(request.Context())
+	redirectLease, err := selector.AcquireForRequest(redirectRequest)
+	require.NoError(t, err)
+
+	require.Equal(t, firstLease, redirectLease)
+	selector.ReportSuccess(firstLease)
+	nextLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, firstLease.ProxyURL, nextLease.ProxyURL)
+}
+
 func TestProxyLeaseSelectorRotatesProviderImmediatelyAndAdvancesUserOnReturn(t *testing.T) {
 	t.Parallel()
 

--- a/crawler/proxy_lease_selector_test.go
+++ b/crawler/proxy_lease_selector_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/stretchr/testify/require"
@@ -166,15 +167,130 @@ func TestProxyLeaseSelectorValidationDuplicateAndReleaseBranches(t *testing.T) {
 
 	firstLease := selector.Acquire()
 	secondLease := selector.Acquire()
-	thirdLease := selector.Acquire()
 
 	require.Equal(t, "http://shared.example:8080", firstLease.ProxyURL)
 	require.Equal(t, "http://unique.example:8080", secondLease.ProxyURL)
-	require.Equal(t, "http://shared.example:8080", thirdLease.ProxyURL)
+
+	_, err = selector.AcquireRequired()
+	require.ErrorIs(t, err, ErrProxyLeaseCandidatesExhausted)
 
 	selector.Release(firstLease)
 	reusedLease := selector.Acquire()
 	require.Equal(t, firstLease.ProxyURL, reusedLease.ProxyURL)
+}
+
+func TestProxyLeaseSelectorCooldownSkipsPausedLeasesAndExhausts(t *testing.T) {
+	t.Parallel()
+
+	currentTime := time.Unix(0, 0)
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{
+			{
+				Name: "provider-one",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-one.example:8080"},
+					{Name: "user-two", URL: "http://provider-two.example:8080"},
+				},
+			},
+		},
+		ProxyLeaseSelectorCircuitBreaker(true),
+		ProxyLeaseSelectorClock(func() time.Time { return currentTime }),
+	)
+	require.NoError(t, err)
+
+	firstLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://provider-one.example:8080", firstLease.ProxyURL)
+
+	selector.ReportCriticalFailure(firstLease)
+	require.False(t, selector.IsAvailable(firstLease.ProxyURL))
+	require.True(t, selector.IsAvailable(""))
+	selector.RecordCriticalFailure("http://unknown.example:8080")
+
+	secondLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://provider-two.example:8080", secondLease.ProxyURL)
+
+	selector.ReportCriticalFailure(secondLease)
+	_, err = selector.AcquireRequired()
+	require.ErrorIs(t, err, ErrProxyLeaseCandidatesExhausted)
+
+	currentTime = currentTime.Add(defaultProxyCooldownBase + time.Second)
+	recoveredLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "http://provider-one.example:8080", recoveredLease.ProxyURL)
+	selector.ReportSuccess(recoveredLease)
+	require.True(t, selector.IsAvailable(recoveredLease.ProxyURL))
+
+	recoveredLease, err = selector.AcquireRequired()
+	require.NoError(t, err)
+	selector.RecordCriticalFailure(recoveredLease.ProxyURL)
+	require.False(t, selector.IsAvailable(recoveredLease.ProxyURL))
+}
+
+func TestProxyLeaseSelectorStartsAtConfiguredProvider(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{
+			{
+				Name: "provider-one",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-one.example:8080"},
+				},
+			},
+			{
+				Name: "provider-two",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-two.example:8080"},
+				},
+			},
+		},
+		ProxyLeaseSelectorStartProvider(1),
+	)
+	require.NoError(t, err)
+
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "provider-two", lease.ProviderName)
+	require.Equal(t, "http://provider-two.example:8080", lease.ProxyURL)
+
+	selector, err = NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{
+			{
+				Name: "provider-one",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://provider-one.example:8080"},
+				},
+			},
+		},
+		ProxyLeaseSelectorStartProvider(-1),
+	)
+	require.NoError(t, err)
+	lease, err = selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, "provider-one", lease.ProviderName)
+	require.Equal(t, 0, normalizeProxyProviderIndex(0, 0))
+}
+
+func TestProxyLeaseSelectorRecordsNonCriticalFailureWithCooldownTracker(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		[]ProxyRotationProviderConfig{{
+			Name: "provider-one",
+			Users: []ProxyRotationUserConfig{{
+				Name: "user-one",
+				URL:  "http://provider-one.example:8080",
+			}},
+		}},
+		ProxyLeaseSelectorCircuitBreaker(true),
+	)
+	require.NoError(t, err)
+	lease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	selector.ReportFailure(lease)
 }
 
 func TestProxyLeaseSelectorAcquireForRequestAttachesSelection(t *testing.T) {
@@ -221,6 +337,9 @@ func TestProxyLeaseSelectorCompatibilityStringReports(t *testing.T) {
 	selector.ReportSuccess(ProxyLease{})
 	selector.RecordFailure("http://unknown.example:8080")
 	selector.RecordSuccess("http://unknown.example:8080")
+	selector.RecordCriticalFailure("http://unknown.example:8080")
+	var nilSelector *ProxyLeaseSelector
+	nilSelector.RecordCriticalFailure("http://unknown.example:8080")
 	selector.RecordSuccess(lease.ProxyURL)
 
 	reusedLease := selector.Acquire()
@@ -313,6 +432,22 @@ func TestProxyLeaseUnavailableErrorWraps(t *testing.T) {
 	require.True(t, errors.Is(err, ErrProxyLeaseUnavailable))
 }
 
+func TestScraperConfigProxyCandidateCountPrefersSelector(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://proxy-one.example:8080"},
+			{Name: "user-two", URL: "http://proxy-two.example:8080"},
+		},
+	}})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, (ScraperConfig{ProxyLeaseSelector: selector, ProxyList: []string{"http://legacy.example:8080"}}).ProxyCandidateCount())
+	require.Equal(t, 1, (ScraperConfig{ProxyList: []string{"http://legacy.example:8080"}}).ProxyCandidateCount())
+}
+
 func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 	t.Parallel()
 
@@ -356,10 +491,11 @@ func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 
 	selector.reservations = map[string]int{"http://proxy-one.example:8080": 1}
 	lease := selector.Acquire()
-	require.Equal(t, "http://proxy-one.example:8080", lease.ProxyURL)
+	require.False(t, lease.Valid())
 
 	emptySelector := &ProxyLeaseSelector{reservations: map[string]int{}}
 	require.False(t, emptySelector.Acquire().Valid())
+	require.False(t, emptySelector.acquireLocked().Valid())
 
 	selection, found = selector.SelectionForProxyURL(" ")
 	require.False(t, found)
@@ -381,4 +517,10 @@ func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 	proxyURL, err := rotationSelector.Select(request)
 	require.Error(t, err)
 	require.Nil(t, proxyURL)
+
+	selector.recordFailureLocked("http://proxy-one.example:8080")
+	selector.recordSuccessLocked("http://proxy-one.example:8080")
+	selector.reservations = map[string]int{"http://proxy-one.example:8080": 2}
+	selector.Release(ProxyLease{ProxyURL: "http://proxy-one.example:8080"})
+	require.Equal(t, 1, selector.reservations["http://proxy-one.example:8080"])
 }

--- a/crawler/proxy_rotation_selector.go
+++ b/crawler/proxy_rotation_selector.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 )
@@ -65,6 +66,46 @@ type proxyRotationProvider struct {
 	nextUser int
 }
 
+type proxyLeaseSelectorOptions struct {
+	circuitBreakerEnabled bool
+	startProviderIndex    int
+	hasStartProviderIndex bool
+	logger                Logger
+	now                   func() time.Time
+}
+
+// ProxyLeaseSelectorOption configures proxy lease selector runtime behavior.
+type ProxyLeaseSelectorOption func(*proxyLeaseSelectorOptions)
+
+// ProxyLeaseSelectorCircuitBreaker enables or disables cooldown tracking.
+func ProxyLeaseSelectorCircuitBreaker(enabled bool) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.circuitBreakerEnabled = enabled
+	}
+}
+
+// ProxyLeaseSelectorStartProvider sets the initial active provider index.
+func ProxyLeaseSelectorStartProvider(index int) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.startProviderIndex = index
+		options.hasStartProviderIndex = true
+	}
+}
+
+// ProxyLeaseSelectorLogger sets the selector logger used for cooldown notices.
+func ProxyLeaseSelectorLogger(logger Logger) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.logger = logger
+	}
+}
+
+// ProxyLeaseSelectorClock injects the selector clock for deterministic tests.
+func ProxyLeaseSelectorClock(now func() time.Time) ProxyLeaseSelectorOption {
+	return func(options *proxyLeaseSelectorOptions) {
+		options.now = now
+	}
+}
+
 // ProxyLeaseSelector acquires proxy leases from ordered providers and keeps
 // successful leases sticky until a failure advances rotation.
 type ProxyLeaseSelector struct {
@@ -74,6 +115,7 @@ type ProxyLeaseSelector struct {
 	activeProvider   int
 	generation       uint64
 	reservations     map[string]int
+	healthTracker    *proxyHealthTracker
 }
 
 // ProxyLeaseAttemptScope tracks failed proxy leases for one scrape, request
@@ -85,8 +127,22 @@ type ProxyLeaseAttemptScope struct {
 
 // NewProxyLeaseSelector constructs a provider-aware lease selector.
 func NewProxyLeaseSelector(configs []ProxyRotationProviderConfig) (*ProxyLeaseSelector, error) {
+	return NewProxyLeaseSelectorWithOptions(configs)
+}
+
+// NewProxyLeaseSelectorWithOptions constructs a provider-aware lease selector
+// with runtime options such as cooldowns and initial provider position.
+func NewProxyLeaseSelectorWithOptions(configs []ProxyRotationProviderConfig, optionList ...ProxyLeaseSelectorOption) (*ProxyLeaseSelector, error) {
+	options := proxyLeaseSelectorOptions{}
+	for _, option := range optionList {
+		if option != nil {
+			option(&options)
+		}
+	}
+
 	providers := make([]proxyRotationProvider, 0, len(configs))
 	selectionByProxy := make(map[string]proxySelectionIndex)
+	proxyURLs := make([]string, 0)
 	for _, providerConfig := range configs {
 		providerName := strings.TrimSpace(providerConfig.Name)
 		if providerName == "" {
@@ -120,6 +176,7 @@ func NewProxyLeaseSelector(configs []ProxyRotationProviderConfig) (*ProxyLeaseSe
 				raw:    trimmedProxyURL,
 				parsed: parsedProxyURL,
 			})
+			proxyURLs = append(proxyURLs, trimmedProxyURL)
 		}
 		if len(users) == 0 {
 			continue
@@ -132,10 +189,26 @@ func NewProxyLeaseSelector(configs []ProxyRotationProviderConfig) (*ProxyLeaseSe
 	if len(providers) == 0 {
 		return nil, nil
 	}
+
+	activeProvider := 0
+	if options.hasStartProviderIndex {
+		activeProvider = normalizeProxyProviderIndex(options.startProviderIndex, len(providers))
+	}
+
+	var healthTracker *proxyHealthTracker
+	if options.circuitBreakerEnabled {
+		healthTracker = newProxyHealthTracker(proxyURLs, options.logger)
+		if options.now != nil {
+			healthTracker.now = options.now
+		}
+	}
+
 	return &ProxyLeaseSelector{
 		providers:        providers,
 		selectionByProxy: selectionByProxy,
+		activeProvider:   activeProvider,
 		reservations:     map[string]int{},
+		healthTracker:    healthTracker,
 	}, nil
 }
 
@@ -147,28 +220,14 @@ func NewProxyLeaseAttemptScope() *ProxyLeaseAttemptScope {
 
 // Acquire reserves and returns the best current proxy lease.
 func (selector *ProxyLeaseSelector) Acquire() ProxyLease {
-	if selector == nil {
-		return ProxyLease{}
-	}
-
-	selector.mu.Lock()
-	defer selector.mu.Unlock()
-
-	lease := selector.acquireLocked()
-	if lease.Valid() {
-		selector.reservations[lease.ProxyURL]++
-	}
+	lease, _ := selector.acquire()
 	return lease
 }
 
 // AcquireRequired reserves and returns a proxy lease or a typed unavailable
 // error when no proxy is configured.
 func (selector *ProxyLeaseSelector) AcquireRequired() (ProxyLease, error) {
-	lease := selector.Acquire()
-	if !lease.Valid() {
-		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
-	}
-	return lease, nil
+	return selector.acquire()
 }
 
 // CandidateCount returns the number of configured proxy candidates.
@@ -198,6 +257,16 @@ func (selector *ProxyLeaseSelector) AcquireForRequest(request *http.Request) (Pr
 	return lease, nil
 }
 
+// Select returns the currently active provider/user tuple as a Colly proxy
+// function.
+func (selector *ProxyLeaseSelector) Select(request *http.Request) (*url.URL, error) {
+	lease, err := selector.AcquireForRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	return lease.proxyURL()
+}
+
 // Release releases a previously acquired lease reservation without reporting
 // success or failure.
 func (selector *ProxyLeaseSelector) Release(lease ProxyLease) {
@@ -213,6 +282,15 @@ func (selector *ProxyLeaseSelector) Release(lease ProxyLease) {
 
 // ReportFailure releases a lease and rotates immediately to the next provider.
 func (selector *ProxyLeaseSelector) ReportFailure(lease ProxyLease) {
+	selector.reportFailure(lease, false)
+}
+
+// ReportCriticalFailure releases a lease and immediately cools the proxy.
+func (selector *ProxyLeaseSelector) ReportCriticalFailure(lease ProxyLease) {
+	selector.reportFailure(lease, true)
+}
+
+func (selector *ProxyLeaseSelector) reportFailure(lease ProxyLease, critical bool) {
 	if selector == nil || !lease.Valid() {
 		return
 	}
@@ -222,7 +300,15 @@ func (selector *ProxyLeaseSelector) ReportFailure(lease ProxyLease) {
 
 	selector.releaseLocked(lease)
 	selectionIndex, found := selector.selectionByProxy[strings.TrimSpace(lease.ProxyURL)]
-	if !found || lease.Generation != selector.generation {
+	if !found {
+		return
+	}
+	if critical {
+		selector.recordCriticalFailureLocked(lease.ProxyURL)
+	} else {
+		selector.recordFailureLocked(lease.ProxyURL)
+	}
+	if lease.Generation != selector.generation {
 		return
 	}
 
@@ -253,6 +339,7 @@ func (selector *ProxyLeaseSelector) ReportSuccess(lease ProxyLease) {
 	if !found || lease.Generation != selector.generation {
 		return
 	}
+	selector.recordSuccessLocked(lease.ProxyURL)
 
 	provider := &selector.providers[selectionIndex.provider]
 	activeUserIndex := provider.nextUser % len(provider.users)
@@ -280,6 +367,25 @@ func (selector *ProxyLeaseSelector) RecordSuccess(proxyURL string) {
 		return
 	}
 	selector.ReportSuccess(selection)
+}
+
+// RecordCriticalFailure keeps string-only callers compatible.
+func (selector *ProxyLeaseSelector) RecordCriticalFailure(proxyURL string) {
+	selection, found := selector.SelectionForProxyURL(proxyURL)
+	if !found {
+		return
+	}
+	selector.ReportCriticalFailure(selection)
+}
+
+// IsAvailable reports whether a proxy is outside cooldown.
+func (selector *ProxyLeaseSelector) IsAvailable(proxyURL string) bool {
+	if selector == nil || strings.TrimSpace(proxyURL) == "" {
+		return true
+	}
+	selector.mu.Lock()
+	defer selector.mu.Unlock()
+	return selector.isAvailableLocked(proxyURL)
 }
 
 // SelectionForProxyURL returns the current-generation selection metadata for a
@@ -389,6 +495,29 @@ func proxyLeaseAttemptScopeKey(lease ProxyLease) string {
 	}, "\x00")
 }
 
+func (selector *ProxyLeaseSelector) acquire() (ProxyLease, error) {
+	if selector == nil {
+		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
+	}
+
+	selector.mu.Lock()
+	defer selector.mu.Unlock()
+
+	if len(selector.providers) == 0 {
+		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
+	}
+	candidateCount := selector.candidateCountLocked()
+	if candidateCount == 0 {
+		return ProxyLease{}, fmt.Errorf("%w: no proxy providers configured", ErrProxyLeaseUnavailable)
+	}
+	lease := selector.acquireLocked()
+	if !lease.Valid() {
+		return ProxyLease{}, ProxyLeaseCandidatesExhaustedError(candidateCount)
+	}
+	selector.reservations[lease.ProxyURL]++
+	return lease, nil
+}
+
 func (selector *ProxyLeaseSelector) acquireLocked() ProxyLease {
 	if len(selector.providers) == 0 {
 		return ProxyLease{}
@@ -407,7 +536,7 @@ func (selector *ProxyLeaseSelector) acquireLocked() ProxyLease {
 		}
 	}
 
-	return selector.leastReservedLeaseLocked()
+	return ProxyLease{}
 }
 
 func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(providerIndex int) (ProxyLease, bool) {
@@ -430,38 +559,12 @@ func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(provi
 		if selector.reservations[candidateUser.raw] > 0 {
 			continue
 		}
+		if !selector.isAvailableLocked(candidateUser.raw) {
+			continue
+		}
 		return selector.leaseForProviderUser(provider, candidateUser), true
 	}
 	return ProxyLease{}, false
-}
-
-func (selector *ProxyLeaseSelector) leastReservedLeaseLocked() ProxyLease {
-	fallbackLease := ProxyLease{}
-	fallbackReservations := 0
-	fallbackSet := false
-	for providerOffset := 0; providerOffset < len(selector.providers); providerOffset++ {
-		providerIndex := (selector.activeProvider + providerOffset) % len(selector.providers)
-		provider := selector.providers[providerIndex]
-		if len(provider.users) == 0 {
-			continue
-		}
-		userIndex := provider.nextUser
-		if userIndex < 0 || userIndex >= len(provider.users) {
-			userIndex = 0
-		}
-		for userOffset := 0; userOffset < len(provider.users); userOffset++ {
-			candidateUserIndex := (userIndex + userOffset) % len(provider.users)
-			candidateUser := provider.users[candidateUserIndex]
-			reservations := selector.reservations[candidateUser.raw]
-			if fallbackSet && reservations >= fallbackReservations {
-				continue
-			}
-			fallbackLease = selector.leaseForProviderUser(provider, candidateUser)
-			fallbackReservations = reservations
-			fallbackSet = true
-		}
-	}
-	return fallbackLease
 }
 
 func (selector *ProxyLeaseSelector) leaseForProviderUser(provider proxyRotationProvider, user proxyRotationUser) ProxyLease {
@@ -473,6 +576,44 @@ func (selector *ProxyLeaseSelector) leaseForProviderUser(provider proxyRotationP
 	}
 }
 
+func (lease ProxyLease) proxyURL() (*url.URL, error) {
+	parsedProxyURL, err := url.Parse(lease.ProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("proxy lease selector: invalid selected proxy URL %q: %w", lease.ProxyURL, err)
+	}
+	return parsedProxyURL, nil
+}
+
+func (selector *ProxyLeaseSelector) candidateCountLocked() int {
+	candidateCount := 0
+	for _, provider := range selector.providers {
+		candidateCount += len(provider.users)
+	}
+	return candidateCount
+}
+
+func (selector *ProxyLeaseSelector) isAvailableLocked(proxyURL string) bool {
+	return selector.healthTracker == nil || selector.healthTracker.IsAvailable(proxyURL)
+}
+
+func (selector *ProxyLeaseSelector) recordSuccessLocked(proxyURL string) {
+	if selector.healthTracker != nil {
+		selector.healthTracker.RecordSuccess(proxyURL)
+	}
+}
+
+func (selector *ProxyLeaseSelector) recordFailureLocked(proxyURL string) {
+	if selector.healthTracker != nil {
+		selector.healthTracker.RecordFailure(proxyURL)
+	}
+}
+
+func (selector *ProxyLeaseSelector) recordCriticalFailureLocked(proxyURL string) {
+	if selector.healthTracker != nil {
+		selector.healthTracker.RecordCriticalFailure(proxyURL)
+	}
+}
+
 func (selector *ProxyLeaseSelector) releaseLocked(lease ProxyLease) {
 	reservations := selector.reservations[strings.TrimSpace(lease.ProxyURL)]
 	switch {
@@ -481,6 +622,13 @@ func (selector *ProxyLeaseSelector) releaseLocked(lease ProxyLease) {
 	default:
 		selector.reservations[strings.TrimSpace(lease.ProxyURL)] = reservations - 1
 	}
+}
+
+func normalizeProxyProviderIndex(index int, providerCount int) int {
+	if providerCount <= 0 {
+		return 0
+	}
+	return ((index % providerCount) + providerCount) % providerCount
 }
 
 // ProxyRotationSelector keeps one (provider, user) selection sticky until a
@@ -507,17 +655,11 @@ func (selector *ProxyRotationSelector) Select(request *http.Request) (*url.URL, 
 	if selector == nil || selector.leaseSelector == nil {
 		return nil, nil
 	}
-
-	lease := selector.leaseSelector.Acquire()
-	if !lease.Valid() {
+	proxyURL, err := selector.leaseSelector.Select(request)
+	if errors.Is(err, ErrProxyLeaseUnavailable) {
 		return nil, nil
 	}
-	AttachProxySelection(request, lease)
-	parsedProxyURL, err := url.Parse(lease.ProxyURL)
-	if err != nil {
-		return nil, fmt.Errorf("proxy rotation selector: invalid selected proxy URL %q: %w", lease.ProxyURL, err)
-	}
-	return parsedProxyURL, nil
+	return proxyURL, err
 }
 
 // RecordFailure keeps string-only callers compatible.
@@ -543,6 +685,14 @@ func (selector *ProxyRotationSelector) RecordProxyFailure(selection ProxySelecti
 		return
 	}
 	selector.leaseSelector.ReportFailure(selection)
+}
+
+// RecordProxyCriticalFailure cools the selected proxy immediately.
+func (selector *ProxyRotationSelector) RecordProxyCriticalFailure(selection ProxySelection) {
+	if selector == nil || selector.leaseSelector == nil {
+		return
+	}
+	selector.leaseSelector.ReportCriticalFailure(selection)
 }
 
 // RecordProxySuccess makes the successful provider/user tuple sticky until the

--- a/crawler/proxy_rotation_selector.go
+++ b/crawler/proxy_rotation_selector.go
@@ -249,6 +249,9 @@ func (selector *ProxyLeaseSelector) CandidateCount() int {
 // AcquireForRequest reserves a lease and attaches it to the request context for
 // HTTP and Colly callers.
 func (selector *ProxyLeaseSelector) AcquireForRequest(request *http.Request) (ProxyLease, error) {
+	if selection, found := SelectedProxySelection(request); found {
+		return selection, nil
+	}
 	lease, err := selector.AcquireRequired()
 	if err != nil {
 		return ProxyLease{}, err

--- a/crawler/proxy_rotation_selector_test.go
+++ b/crawler/proxy_rotation_selector_test.go
@@ -269,6 +269,9 @@ func TestProxyRotationSelectorNilEmptyAndUnknownBranches(t *testing.T) {
 	require.NotPanics(t, func() { nilSelector.RecordFailure("http://unknown.example:8080") })
 	require.NotPanics(t, func() { nilSelector.RecordSuccess("http://unknown.example:8080") })
 	require.NotPanics(t, func() { nilSelector.RecordProxyFailure(ProxySelection{ProxyURL: "http://unknown.example:8080"}) })
+	require.NotPanics(t, func() {
+		nilSelector.RecordProxyCriticalFailure(ProxySelection{ProxyURL: "http://unknown.example:8080"})
+	})
 	require.NotPanics(t, func() { nilSelector.RecordProxySuccess(ProxySelection{ProxyURL: "http://unknown.example:8080"}) })
 	selection, found := nilSelector.SelectionForProxyURL("http://unknown.example:8080")
 	require.False(t, found)
@@ -299,6 +302,7 @@ func TestProxyRotationSelectorNilEmptyAndUnknownBranches(t *testing.T) {
 	selector.RecordFailure("http://unknown.example:8080")
 	selector.RecordSuccess("http://unknown.example:8080")
 	selector.RecordProxyFailure(ProxySelection{})
+	selector.RecordProxyCriticalFailure(ProxySelection{})
 	selector.RecordProxySuccess(ProxySelection{})
 	selector.RecordProxyFailure(ProxySelection{ProxyURL: "http://unknown.example:8080"})
 	selector.RecordProxySuccess(ProxySelection{ProxyURL: "http://unknown.example:8080"})

--- a/crawler/proxy_selection_tracking.go
+++ b/crawler/proxy_selection_tracking.go
@@ -1,0 +1,264 @@
+package crawler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gocolly/colly/v2"
+)
+
+type proxySelectionTrackerContextKey struct{}
+
+type proxySelectionTracker struct {
+	requestID string
+}
+
+type proxySelectionTrackingTransport struct {
+	base http.RoundTripper
+}
+
+var trackedProxySelections sync.Map
+var trackedProxySelectionLinks sync.Map
+var proxySelectionRequestSequence atomic.Uint64
+
+const proxySelectionTrackingHeader = "X-Crawler-Proxy-Tracking"
+const proxySelectionTrackingLinkHeader = "X-Crawler-Proxy-Tracking-Link"
+const proxySelectionCollyContextKey = "crawler_proxy_selection"
+const proxySelectionTrackingLinkContextKey = "crawler_proxy_selection_tracking_link"
+
+func installProxySelectionTracking(collector *colly.Collector, transport *http.Transport, runtimeTransport http.RoundTripper) {
+	if collector == nil || transport == nil || runtimeTransport == nil || transport.Proxy == nil {
+		return
+	}
+	wrapHTTPTransportProxySelector(transport)
+	collector.OnRequest(func(request *colly.Request) {
+		assignProxySelectionTrackingID(request)
+	})
+	collector.OnError(func(response *colly.Response, _ error) {
+		applyTrackedProxySelection(response)
+		clearTrackedProxySelection(response.Request)
+	})
+	collector.OnResponse(func(response *colly.Response) {
+		applyTrackedProxySelection(response)
+		clearTrackedProxySelection(response.Request)
+	})
+	collector.WithTransport(&proxySelectionTrackingTransport{base: runtimeTransport})
+}
+
+func (transport *proxySelectionTrackingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request == nil {
+		return transport.base.RoundTrip(request)
+	}
+	requestID := strings.TrimSpace(request.Header.Get(proxySelectionTrackingHeader))
+	linkID := strings.TrimSpace(request.Header.Get(proxySelectionTrackingLinkHeader))
+	if requestID == "" && linkID == "" {
+		return transport.base.RoundTrip(request)
+	}
+	updatedContext := request.Context()
+	if requestID != "" {
+		tracker := &proxySelectionTracker{requestID: requestID}
+		updatedContext = context.WithValue(updatedContext, proxySelectionTrackerContextKey{}, tracker)
+	}
+	if requestID != "" && linkID != "" {
+		trackedProxySelectionLinks.Store(linkID, requestID)
+	}
+	updatedRequest := request.Clone(updatedContext)
+	updatedRequest.Header.Del(proxySelectionTrackingHeader)
+	updatedRequest.Header.Del(proxySelectionTrackingLinkHeader)
+	return transport.base.RoundTrip(updatedRequest)
+}
+
+func wrapHTTPTransportProxySelector(transport *http.Transport) {
+	if transport == nil || transport.Proxy == nil {
+		return
+	}
+	delegate := transport.Proxy
+	transport.Proxy = func(request *http.Request) (*url.URL, error) {
+		return trackSelectedProxyURL(request, delegate)
+	}
+}
+
+func trackSelectedProxyURL(
+	request *http.Request,
+	delegate func(*http.Request) (*url.URL, error),
+) (*url.URL, error) {
+	if delegate == nil {
+		return nil, nil
+	}
+	if request == nil {
+		return nil, errors.New("crawler: cannot select proxy for nil request")
+	}
+
+	proxyURL, err := delegate(request)
+	if err != nil {
+		return proxyURL, err
+	}
+	if proxyURL == nil {
+		return nil, nil
+	}
+
+	tracker, _ := request.Context().Value(proxySelectionTrackerContextKey{}).(*proxySelectionTracker)
+	if tracker != nil && tracker.requestID != "" {
+		selection, found := SelectedProxySelection(request)
+		if !found {
+			selection = ProxySelection{ProxyURL: proxyURL.String()}
+		}
+		trackedProxySelections.Store(tracker.requestID, selection)
+	}
+	return proxyURL, nil
+}
+
+func assignProxySelectionTrackingID(request *colly.Request) {
+	if request == nil || request.Headers == nil {
+		return
+	}
+	requestID := strings.TrimSpace(request.Headers.Get(proxySelectionTrackingHeader))
+	if requestID == "" {
+		requestID = nextProxySelectionTrackingID()
+		request.Headers.Set(proxySelectionTrackingHeader, requestID)
+	}
+	linkID := ensureProxySelectionTrackingLinkID(request)
+	if linkID != "" {
+		request.Headers.Set(proxySelectionTrackingLinkHeader, linkID)
+	}
+}
+
+func nextProxySelectionTrackingID() string {
+	return strconv.FormatUint(proxySelectionRequestSequence.Add(1), 10)
+}
+
+func applyTrackedProxySelection(response *colly.Response) {
+	if response == nil || response.Request == nil {
+		return
+	}
+	requestID := requestProxySelectionTrackingID(response.Request)
+	if requestID == "" {
+		return
+	}
+	defer clearTrackedProxySelection(response.Request)
+	proxyValue, ok := trackedProxySelections.Load(requestID)
+	if !ok {
+		return
+	}
+	switch trackedSelection := proxyValue.(type) {
+	case ProxySelection:
+		if strings.TrimSpace(trackedSelection.ProxyURL) == "" {
+			return
+		}
+		if response.Request.ProxyURL == "" {
+			response.Request.ProxyURL = trackedSelection.ProxyURL
+		}
+		attachTrackedProxySelection(response.Request, trackedSelection)
+	case string:
+		proxyURL := strings.TrimSpace(trackedSelection)
+		if proxyURL == "" {
+			return
+		}
+		if response.Request.ProxyURL == "" {
+			response.Request.ProxyURL = proxyURL
+		}
+	}
+}
+
+func clearTrackedProxySelection(request *colly.Request) {
+	requestID := requestProxySelectionTrackingID(request)
+	linkID := requestProxySelectionTrackingLinkID(request)
+	if requestID != "" {
+		trackedProxySelections.Delete(requestID)
+	}
+	if linkID != "" {
+		trackedProxySelectionLinks.Delete(linkID)
+		if request != nil && request.Ctx != nil {
+			request.Ctx.Put(proxySelectionTrackingLinkContextKey, "")
+		}
+	}
+	if request == nil || request.Headers == nil {
+		return
+	}
+	request.Headers.Del(proxySelectionTrackingHeader)
+	request.Headers.Del(proxySelectionTrackingLinkHeader)
+}
+
+func requestProxySelectionTrackingID(request *colly.Request) string {
+	if request == nil {
+		return ""
+	}
+	if request.Headers != nil {
+		requestID := strings.TrimSpace(request.Headers.Get(proxySelectionTrackingHeader))
+		if requestID != "" {
+			return requestID
+		}
+	}
+	linkID := requestProxySelectionTrackingLinkID(request)
+	if linkID == "" {
+		return ""
+	}
+	trackedRequestID, ok := trackedProxySelectionLinks.Load(linkID)
+	if !ok {
+		return ""
+	}
+	requestID, ok := trackedRequestID.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(requestID)
+}
+
+func requestProxySelectionTrackingLinkID(request *colly.Request) string {
+	if request == nil {
+		return ""
+	}
+	if request.Ctx != nil {
+		linkID := strings.TrimSpace(request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+		if linkID != "" {
+			return linkID
+		}
+	}
+	if request.Headers == nil {
+		return ""
+	}
+	return strings.TrimSpace(request.Headers.Get(proxySelectionTrackingLinkHeader))
+}
+
+func ensureProxySelectionTrackingLinkID(request *colly.Request) string {
+	if request == nil {
+		return ""
+	}
+	if request.Ctx == nil {
+		request.Ctx = colly.NewContext()
+	}
+	linkID := strings.TrimSpace(request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+	if linkID != "" {
+		return linkID
+	}
+	linkID = nextProxySelectionTrackingID()
+	request.Ctx.Put(proxySelectionTrackingLinkContextKey, linkID)
+	return linkID
+}
+
+func attachTrackedProxySelection(request *colly.Request, selection ProxySelection) {
+	if request == nil {
+		return
+	}
+	if request.Ctx == nil {
+		request.Ctx = colly.NewContext()
+	}
+	request.Ctx.Put(proxySelectionCollyContextKey, selection)
+}
+
+func selectedProxySelectionFromCollyRequest(request *colly.Request) (ProxySelection, bool) {
+	if request == nil || request.Ctx == nil {
+		return ProxySelection{}, false
+	}
+	selection, ok := request.Ctx.GetAny(proxySelectionCollyContextKey).(ProxySelection)
+	if !ok || strings.TrimSpace(selection.ProxyURL) == "" {
+		return ProxySelection{}, false
+	}
+	return selection, true
+}

--- a/crawler/proxy_selection_tracking.go
+++ b/crawler/proxy_selection_tracking.go
@@ -69,9 +69,26 @@ func (transport *proxySelectionTrackingTransport) RoundTrip(request *http.Reques
 		trackedProxySelectionLinks.Store(linkID, requestID)
 	}
 	updatedRequest := request.Clone(updatedContext)
+	attachStoredProxySelection(updatedRequest, requestID)
 	updatedRequest.Header.Del(proxySelectionTrackingHeader)
 	updatedRequest.Header.Del(proxySelectionTrackingLinkHeader)
 	return transport.base.RoundTrip(updatedRequest)
+}
+
+func attachStoredProxySelection(request *http.Request, requestID string) {
+	if request == nil || strings.TrimSpace(requestID) == "" {
+		return
+	}
+	storedSelection, found := trackedProxySelections.Load(strings.TrimSpace(requestID))
+	if !found {
+		return
+	}
+	switch selection := storedSelection.(type) {
+	case ProxySelection:
+		AttachProxySelection(request, selection)
+	case string:
+		AttachProxySelection(request, ProxySelection{ProxyURL: strings.TrimSpace(selection)})
+	}
 }
 
 func wrapHTTPTransportProxySelector(transport *http.Transport) {

--- a/crawler/proxy_selection_tracking_test.go
+++ b/crawler/proxy_selection_tracking_test.go
@@ -1,0 +1,301 @@
+package crawler
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gocolly/colly/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type proxyTrackingRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn proxyTrackingRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestInstallProxySelectionTrackingAnnotatesCollyResponses(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://provider-one.example:8080",
+		}},
+	}})
+	require.NoError(t, err)
+
+	transport := &http.Transport{Proxy: selector.Select}
+	runtimeTransport := proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		proxyURL, proxyErr := transport.Proxy(request)
+		require.NoError(t, proxyErr)
+		require.Equal(t, "http://provider-one.example:8080", proxyURL.String())
+		require.Empty(t, request.Header.Get(proxySelectionTrackingHeader))
+		require.Empty(t, request.Header.Get(proxySelectionTrackingLinkHeader))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/html"}},
+			Body:       io.NopCloser(strings.NewReader("<html><head><title>ok</title></head></html>")),
+			Request:    request,
+		}, nil
+	})
+	collector := colly.NewCollector(colly.AllowURLRevisit())
+	installProxySelectionTracking(collector, transport, runtimeTransport)
+
+	var responseSelection ProxySelection
+	var foundSelection bool
+	collector.OnResponse(func(response *colly.Response) {
+		responseSelection, foundSelection = selectedProxySelectionFromResponse(response)
+	})
+
+	err = collector.Request(http.MethodGet, "http://example.com/product", nil, colly.NewContext(), nil)
+	require.NoError(t, err)
+	collector.Wait()
+
+	require.True(t, foundSelection)
+	require.Equal(t, "provider-one", responseSelection.ProviderName)
+	require.Equal(t, "user-one", responseSelection.UserName)
+	require.Equal(t, "http://provider-one.example:8080", responseSelection.ProxyURL)
+}
+
+func TestInstallProxySelectionTrackingAnnotatesCollyErrors(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://provider-one.example:8080",
+		}},
+	}})
+	require.NoError(t, err)
+
+	transport := &http.Transport{Proxy: selector.Select}
+	runtimeTransport := proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		_, proxyErr := transport.Proxy(request)
+		require.NoError(t, proxyErr)
+		return nil, errors.New("request failed")
+	})
+	collector := colly.NewCollector(colly.AllowURLRevisit())
+	installProxySelectionTracking(collector, transport, runtimeTransport)
+
+	var errorSelection ProxySelection
+	var foundSelection bool
+	collector.OnError(func(response *colly.Response, _ error) {
+		errorSelection, foundSelection = selectedProxySelectionFromResponse(response)
+	})
+
+	err = collector.Request(http.MethodGet, "http://example.com/product", nil, colly.NewContext(), nil)
+	require.ErrorContains(t, err, "request failed")
+	collector.Wait()
+
+	require.True(t, foundSelection)
+	require.Equal(t, "provider-one", errorSelection.ProviderName)
+	require.Equal(t, "http://provider-one.example:8080", errorSelection.ProxyURL)
+}
+
+func TestProxySelectionTrackingBoundaryBranches(t *testing.T) {
+	installProxySelectionTracking(nil, nil, nil)
+	installProxySelectionTracking(colly.NewCollector(), nil, proxyTrackingRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+	installProxySelectionTracking(colly.NewCollector(), &http.Transport{}, nil)
+	installProxySelectionTracking(colly.NewCollector(), &http.Transport{}, proxyTrackingRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+
+	transport := &proxySelectionTrackingTransport{base: proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request != nil {
+			require.Empty(t, request.Header.Get(proxySelectionTrackingHeader))
+			require.Empty(t, request.Header.Get(proxySelectionTrackingLinkHeader))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    request,
+		}, nil
+	})}
+
+	response, err := transport.RoundTrip(nil)
+	require.NoError(t, err)
+	require.Nil(t, response.Request)
+
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	response, err = transport.RoundTrip(request)
+	require.NoError(t, err)
+	require.Same(t, request, response.Request)
+
+	request.Header.Set(proxySelectionTrackingHeader, "request-one")
+	request.Header.Set(proxySelectionTrackingLinkHeader, "link-one")
+	response, err = transport.RoundTrip(request)
+	require.NoError(t, err)
+	require.NotSame(t, request, response.Request)
+	require.Equal(t, "request-one", response.Request.Context().Value(proxySelectionTrackerContextKey{}).(*proxySelectionTracker).requestID)
+	trackedRequestID, found := trackedProxySelectionLinks.Load("link-one")
+	require.True(t, found)
+	require.Equal(t, "request-one", trackedRequestID)
+}
+
+func TestTrackSelectedProxyURLBoundaryBranches(t *testing.T) {
+	wrapHTTPTransportProxySelector(nil)
+	wrapHTTPTransportProxySelector(&http.Transport{})
+
+	proxyURL, err := trackSelectedProxyURL(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, proxyURL)
+
+	proxyURL, err = trackSelectedProxyURL(nil, func(*http.Request) (*url.URL, error) {
+		return nil, nil
+	})
+	require.ErrorContains(t, err, "nil request")
+	require.Nil(t, proxyURL)
+
+	expectedErr := errors.New("select failed")
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	proxyURL, err = trackSelectedProxyURL(request, func(*http.Request) (*url.URL, error) {
+		parsedProxyURL, parseErr := url.Parse("http://proxy.example:8080")
+		require.NoError(t, parseErr)
+		return parsedProxyURL, expectedErr
+	})
+	require.ErrorIs(t, err, expectedErr)
+	require.Equal(t, "http://proxy.example:8080", proxyURL.String())
+
+	proxyURL, err = trackSelectedProxyURL(request, func(*http.Request) (*url.URL, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, proxyURL)
+
+	proxyURL, err = trackSelectedProxyURL(request, func(*http.Request) (*url.URL, error) {
+		return url.Parse("http://proxy.example:8080")
+	})
+	require.NoError(t, err)
+	require.Equal(t, "http://proxy.example:8080", proxyURL.String())
+
+	trackedRequest, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	trackedRequest = trackedRequest.WithContext(context.WithValue(
+		trackedRequest.Context(),
+		proxySelectionTrackerContextKey{},
+		&proxySelectionTracker{requestID: "fallback-selection"},
+	))
+	proxyURL, err = trackSelectedProxyURL(trackedRequest, func(*http.Request) (*url.URL, error) {
+		return url.Parse("http://fallback-proxy.example:8080")
+	})
+	require.NoError(t, err)
+	require.Equal(t, "http://fallback-proxy.example:8080", proxyURL.String())
+	storedSelection, found := trackedProxySelections.Load("fallback-selection")
+	require.True(t, found)
+	require.Equal(t, "http://fallback-proxy.example:8080", storedSelection.(ProxySelection).ProxyURL)
+}
+
+func TestApplyTrackedProxySelectionBoundaryBranches(t *testing.T) {
+	applyTrackedProxySelection(nil)
+	applyTrackedProxySelection(&colly.Response{})
+
+	headers := http.Header{}
+	request := &colly.Request{Headers: &headers, Ctx: colly.NewContext()}
+	applyTrackedProxySelection(&colly.Response{Request: request})
+
+	headers.Set(proxySelectionTrackingHeader, "missing")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Empty(t, request.ProxyURL)
+
+	trackedProxySelections.Store("empty-selection", ProxySelection{})
+	headers.Set(proxySelectionTrackingHeader, "empty-selection")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Empty(t, request.ProxyURL)
+
+	trackedProxySelections.Store("empty-string", "")
+	headers.Set(proxySelectionTrackingHeader, "empty-string")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Empty(t, request.ProxyURL)
+
+	trackedProxySelections.Store("string-selection", "http://string-proxy.example:8080")
+	headers.Set(proxySelectionTrackingHeader, "string-selection")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Equal(t, "http://string-proxy.example:8080", request.ProxyURL)
+
+	request.ProxyURL = "http://existing-proxy.example:8080"
+	trackedProxySelections.Store("lease-selection", ProxySelection{
+		ProviderName: "provider-one",
+		UserName:     "user-one",
+		ProxyURL:     "http://lease-proxy.example:8080",
+	})
+	headers.Set(proxySelectionTrackingHeader, "lease-selection")
+	applyTrackedProxySelection(&colly.Response{Request: request})
+	require.Equal(t, "http://existing-proxy.example:8080", request.ProxyURL)
+	selection, found := selectedProxySelectionFromCollyRequest(request)
+	require.True(t, found)
+	require.Equal(t, "http://lease-proxy.example:8080", selection.ProxyURL)
+}
+
+func TestProxySelectionTrackingIDAndLinkBranches(t *testing.T) {
+	assignProxySelectionTrackingID(nil)
+	assignProxySelectionTrackingID(&colly.Request{})
+
+	headers := http.Header{}
+	request := &colly.Request{Headers: &headers}
+	assignProxySelectionTrackingID(request)
+	require.NotEmpty(t, headers.Get(proxySelectionTrackingHeader))
+	require.NotEmpty(t, headers.Get(proxySelectionTrackingLinkHeader))
+	require.NotEmpty(t, request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+
+	linkID := request.Ctx.Get(proxySelectionTrackingLinkContextKey)
+	headers.Del(proxySelectionTrackingHeader)
+	trackedProxySelectionLinks.Store(linkID, 42)
+	require.Empty(t, requestProxySelectionTrackingID(request))
+
+	trackedProxySelectionLinks.Store(linkID, " linked-request ")
+	require.Equal(t, "linked-request", requestProxySelectionTrackingID(request))
+	require.Equal(t, linkID, requestProxySelectionTrackingLinkID(request))
+
+	clearTrackedProxySelection(request)
+	require.Empty(t, request.Ctx.Get(proxySelectionTrackingLinkContextKey))
+	require.Empty(t, headers.Get(proxySelectionTrackingHeader))
+	require.Empty(t, headers.Get(proxySelectionTrackingLinkHeader))
+	clearTrackedProxySelection(nil)
+
+	require.Empty(t, requestProxySelectionTrackingID(nil))
+	require.Empty(t, requestProxySelectionTrackingLinkID(nil))
+	require.Empty(t, requestProxySelectionTrackingLinkID(&colly.Request{}))
+	require.Empty(t, ensureProxySelectionTrackingLinkID(nil))
+
+	requestWithoutHeaders := &colly.Request{Ctx: colly.NewContext()}
+	requestWithoutHeaders.Ctx.Put(proxySelectionTrackingLinkContextKey, "ctx-link")
+	require.Empty(t, requestProxySelectionTrackingID(requestWithoutHeaders))
+	trackedProxySelectionLinks.Store("ctx-link", "ctx-request")
+	require.Equal(t, "ctx-request", requestProxySelectionTrackingID(requestWithoutHeaders))
+
+	require.Equal(t, "ctx-link", ensureProxySelectionTrackingLinkID(requestWithoutHeaders))
+
+	directHeaderRequest := &colly.Request{Headers: &http.Header{}}
+	directHeaderRequest.Headers.Set(proxySelectionTrackingHeader, "direct-request")
+	require.Equal(t, "direct-request", requestProxySelectionTrackingID(directHeaderRequest))
+
+	require.Empty(t, requestProxySelectionTrackingID(&colly.Request{}))
+}
+
+func TestAttachAndReadTrackedProxySelectionBoundaryBranches(t *testing.T) {
+	attachTrackedProxySelection(nil, ProxySelection{ProxyURL: "http://proxy.example:8080"})
+	request := &colly.Request{}
+	attachTrackedProxySelection(request, ProxySelection{ProxyURL: "http://proxy.example:8080"})
+	selection, found := selectedProxySelectionFromCollyRequest(request)
+	require.True(t, found)
+	require.Equal(t, "http://proxy.example:8080", selection.ProxyURL)
+
+	selection, found = selectedProxySelectionFromCollyRequest(nil)
+	require.False(t, found)
+	require.Empty(t, selection)
+	selection, found = selectedProxySelectionFromCollyRequest(&colly.Request{Ctx: colly.NewContext()})
+	require.False(t, found)
+	require.Empty(t, selection)
+	selection, found = selectedProxySelectionFromResponse(nil)
+	require.False(t, found)
+	require.Empty(t, selection)
+}

--- a/crawler/proxy_selection_tracking_test.go
+++ b/crawler/proxy_selection_tracking_test.go
@@ -140,6 +140,54 @@ func TestProxySelectionTrackingBoundaryBranches(t *testing.T) {
 	require.Equal(t, "request-one", trackedRequestID)
 }
 
+func TestProxySelectionTrackingTransportAttachesStoredSelection(t *testing.T) {
+	storedSelection := ProxySelection{
+		ProviderName: "provider-one",
+		UserName:     "user-one",
+		ProxyURL:     "http://provider-one.example:8080",
+		Generation:   3,
+	}
+	trackedProxySelections.Store("request-one", storedSelection)
+	defer trackedProxySelections.Delete("request-one")
+
+	transport := &proxySelectionTrackingTransport{base: proxyTrackingRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		selection, found := SelectedProxySelection(request)
+		require.True(t, found)
+		require.Equal(t, storedSelection, selection)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Request:    request,
+		}, nil
+	})}
+
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	request.Header.Set(proxySelectionTrackingHeader, "request-one")
+
+	response, err := transport.RoundTrip(request)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+}
+
+func TestAttachStoredProxySelectionBoundaryBranches(t *testing.T) {
+	attachStoredProxySelection(nil, "request-one")
+	request, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+	attachStoredProxySelection(request, " ")
+	attachStoredProxySelection(request, "missing")
+	_, found := SelectedProxySelection(request)
+	require.False(t, found)
+
+	trackedProxySelections.Store("string-request", " http://string-proxy.example:8080 ")
+	defer trackedProxySelections.Delete("string-request")
+	attachStoredProxySelection(request, "string-request")
+	selection, found := SelectedProxySelection(request)
+	require.True(t, found)
+	require.Equal(t, "http://string-proxy.example:8080", selection.ProxyURL)
+}
+
 func TestTrackSelectedProxyURLBoundaryBranches(t *testing.T) {
 	wrapHTTPTransportProxySelector(nil)
 	wrapHTTPTransportProxySelector(&http.Transport{})

--- a/crawler/response.go
+++ b/crawler/response.go
@@ -215,6 +215,12 @@ func (processor *responseProcessor) recordProxySuccess(resp *colly.Response) {
 	if processor.proxyTracker == nil || proxyURL == "" {
 		return
 	}
+	if lease, found := selectedProxySelectionFromResponse(resp); found {
+		if reporter, ok := processor.proxyTracker.(proxyLeaseReporter); ok {
+			reporter.ReportSuccess(lease)
+			return
+		}
+	}
 	processor.proxyTracker.RecordSuccess(proxyURL)
 }
 
@@ -237,16 +243,23 @@ func (processor *responseProcessor) retryByDecision(resp *colly.Response, decisi
 }
 
 func (processor *responseProcessor) alternativeProxyRetryCount() int {
-	if len(processor.scraperConfig.ProxyList) <= 1 {
+	proxyCandidateCount := processor.scraperConfig.ProxyCandidateCount()
+	if proxyCandidateCount <= 1 {
 		return 0
 	}
-	return len(processor.scraperConfig.ProxyList) - 1
+	return proxyCandidateCount - 1
 }
 
 func (processor *responseProcessor) recordCriticalProxyFailure(resp *colly.Response) {
 	proxyURL := responseProxyURL(resp)
 	if processor.proxyTracker == nil || proxyURL == "" {
 		return
+	}
+	if lease, found := selectedProxySelectionFromResponse(resp); found {
+		if reporter, ok := processor.proxyTracker.(proxyLeaseReporter); ok {
+			reporter.ReportCriticalFailure(lease)
+			return
+		}
 	}
 	processor.proxyTracker.RecordCriticalFailure(proxyURL)
 }
@@ -256,6 +269,13 @@ func responseProxyURL(resp *colly.Response) string {
 		return ""
 	}
 	return strings.TrimSpace(resp.Request.ProxyURL)
+}
+
+func selectedProxySelectionFromResponse(resp *colly.Response) (ProxySelection, bool) {
+	if resp == nil {
+		return ProxySelection{}, false
+	}
+	return selectedProxySelectionFromCollyRequest(resp.Request)
 }
 
 func (processor *responseProcessor) inferRedirect(productID, originalURL, finalURL, canonicalURL string, ctx *colly.Context) {

--- a/crawler/retry.go
+++ b/crawler/retry.go
@@ -30,7 +30,7 @@ func newRetryHandler(scraper ScraperConfig, logger Logger) RetryHandler {
 	return &retryHandler{
 		maxRetries:    scraper.RetryCount,
 		logger:        logger,
-		proxyPoolSize: len(scraper.ProxyList),
+		proxyPoolSize: scraper.ProxyCandidateCount(),
 		sleepFn:       time.Sleep,
 	}
 }

--- a/crawler/service.go
+++ b/crawler/service.go
@@ -337,6 +337,11 @@ func recordProxyFailure(tracker proxyHealth, resp *colly.Response) {
 		return
 	}
 	if !shouldRecordProxyFailure(resp.StatusCode) {
+		if lease, found := selectedProxySelectionFromResponse(resp); found {
+			if releaser, ok := tracker.(proxyLeaseReleaser); ok {
+				releaser.Release(lease)
+			}
+		}
 		return
 	}
 	if lease, found := selectedProxySelectionFromResponse(resp); found {

--- a/crawler/service.go
+++ b/crawler/service.go
@@ -73,10 +73,6 @@ func NewService(cfg Config, results chan<- *Result, options ...ServiceOption) (*
 
 	responseProcessor := newResponseProcessor(cfg, retryHandler, proxyTracker, filePersister, results, logger)
 
-	requestConfigurator.Configure(collector)
-	setupErrorHandling(collector, responseProcessor, retryHandler, proxyTracker, logger)
-	responseProcessor.Setup(collector)
-
 	service := &Service{
 		config:              cfg,
 		collector:           collector,
@@ -95,6 +91,7 @@ func NewService(cfg Config, results chan<- *Result, options ...ServiceOption) (*
 		option(service)
 	}
 
+	requestConfigurator.Configure(collector)
 	bindResponseHandlersRuntime(service.responseHandlers, collector, filePersister, retryHandler)
 	responseProcessor.SetResultCallback(service.releaseProductSlot)
 	responseProcessor.SetResponseHandlers(service.responseHandlers)
@@ -102,7 +99,11 @@ func NewService(cfg Config, results chan<- *Result, options ...ServiceOption) (*
 	contextTransport := newContextAwareTransport(transport, service.currentRunContext)
 	panicSafeTransport := newPanicSafeTransport(contextTransport, logger)
 	collector.WithTransport(panicSafeTransport)
+	httpTransport, _ := transport.(*http.Transport)
+	installProxySelectionTracking(collector, httpTransport, panicSafeTransport)
 
+	setupErrorHandling(collector, responseProcessor, retryHandler, proxyTracker, logger)
+	responseProcessor.Setup(collector)
 	service.serviceHook.AfterInit(collector, panicSafeTransport)
 
 	return service, nil
@@ -216,30 +217,53 @@ func newCollector(cfg Config, logger Logger) (*colly.Collector, proxyHealth, htt
 
 	_ = webCollector.Limit(limitRule)
 
-	var tracker proxyHealth
-	proxyHealthEnabled := cfg.Scraper.ProxyCircuitBreakerEnabled
-	switch len(cfg.Scraper.ProxyList) {
-	case 0:
-	case 1:
-		proxyFn, err := newProxyRotator(cfg.Scraper.ProxyList, nil, logger)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		webCollector.SetProxyFunc(proxyFn)
-	default:
-		if proxyHealthEnabled {
-			tracker = newProxyHealthTracker(cfg.Scraper.ProxyList, logger)
-		}
-		proxyFn, err := newProxyRotator(cfg.Scraper.ProxyList, tracker, logger)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		webCollector.SetProxyFunc(proxyFn)
+	proxySelector, err := proxyLeaseSelectorForScraper(cfg.Scraper, logger)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if proxySelector != nil {
+		webCollector.SetProxyFunc(proxySelector.Select)
 	}
 
 	cookieJar, _ := cookiejar.New(nil)
 	webCollector.SetCookieJar(cookieJar)
-	return webCollector, tracker, transport, nil
+	return webCollector, proxySelector, transport, nil
+}
+
+func proxyLeaseSelectorForScraper(scraper ScraperConfig, logger Logger) (*ProxyLeaseSelector, error) {
+	if scraper.ProxyLeaseSelector != nil {
+		return scraper.ProxyLeaseSelector, nil
+	}
+	if len(scraper.ProxyList) == 0 {
+		return nil, nil
+	}
+	providers := []ProxyRotationProviderConfig{{
+		Name:  "flat",
+		Users: proxyUsersFromFlatList(scraper.ProxyList),
+	}}
+	selector, err := NewProxyLeaseSelectorWithOptions(
+		providers,
+		ProxyLeaseSelectorCircuitBreaker(scraper.ProxyCircuitBreakerEnabled),
+		ProxyLeaseSelectorLogger(logger),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("crawler: build proxy selector: %w", err)
+	}
+	if selector == nil {
+		return nil, fmt.Errorf("%w: proxy list is empty", ErrProxyLeaseUnavailable)
+	}
+	return selector, nil
+}
+
+func proxyUsersFromFlatList(proxyURLs []string) []ProxyRotationUserConfig {
+	users := make([]ProxyRotationUserConfig, 0, len(proxyURLs))
+	for index, proxyURL := range proxyURLs {
+		users = append(users, ProxyRotationUserConfig{
+			Name: fmt.Sprintf("proxy-%d", index+1),
+			URL:  proxyURL,
+		})
+	}
+	return users
 }
 
 func shouldOverrideCollectorRequestTimeout(timeout time.Duration) bool {
@@ -312,10 +336,25 @@ func recordProxyFailure(tracker proxyHealth, resp *colly.Response) {
 	if resp.Request.ProxyURL == "" {
 		return
 	}
-	if resp.StatusCode != 0 {
+	if !shouldRecordProxyFailure(resp.StatusCode) {
 		return
 	}
+	if lease, found := selectedProxySelectionFromResponse(resp); found {
+		if reporter, ok := tracker.(proxyLeaseReporter); ok {
+			reporter.ReportFailure(lease)
+			return
+		}
+	}
 	tracker.RecordFailure(resp.Request.ProxyURL)
+}
+
+func shouldRecordProxyFailure(statusCode int) bool {
+	switch statusCode {
+	case 0, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 func (service *Service) reserveProductSlot(ctx context.Context, productID string) error {

--- a/crawler/service_integration_test.go
+++ b/crawler/service_integration_test.go
@@ -219,6 +219,38 @@ func TestNewCollectorSingleProxyAnnotatesRequestContext(t *testing.T) {
 	require.Equal(t, "http://user:pass@proxy-one.test:8080", req.Context().Value(colly.ProxyURLKey))
 }
 
+func TestProxyLeaseSelectorForScraperUsesInjectedSelector(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{{
+			Name: "user-one",
+			URL:  "http://proxy.example:8080",
+		}},
+	}})
+	require.NoError(t, err)
+
+	resolvedSelector, err := proxyLeaseSelectorForScraper(ScraperConfig{
+		ProxyLeaseSelector: selector,
+		ProxyList:          []string{"://bad"},
+	}, noopLogger{})
+	require.NoError(t, err)
+	require.Same(t, selector, resolvedSelector)
+}
+
+func TestProxyLeaseSelectorForScraperHandlesEmptyAndBlankLists(t *testing.T) {
+	t.Parallel()
+
+	selector, err := proxyLeaseSelectorForScraper(ScraperConfig{}, noopLogger{})
+	require.NoError(t, err)
+	require.Nil(t, selector)
+
+	selector, err = proxyLeaseSelectorForScraper(ScraperConfig{ProxyList: []string{" "}}, noopLogger{})
+	require.ErrorIs(t, err, ErrProxyLeaseUnavailable)
+	require.Nil(t, selector)
+}
+
 func TestNewServiceBindsRuntimeToResponseHandlers(t *testing.T) {
 	t.Parallel()
 
@@ -298,6 +330,55 @@ func TestErrorHandlingCountsProxyConnectionFailures(t *testing.T) {
 	require.Equal(t, []string{"http://failing-proxy"}, tracker.failures)
 	require.Len(t, processor.results, 1)
 	require.Equal(t, 0, processor.results[0].statusCode)
+}
+
+func TestProxySelectionTrackingPreservesSelectedLeaseGeneration(t *testing.T) {
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{
+		{
+			Name: "provider-one",
+			Users: []ProxyRotationUserConfig{
+				{Name: "user-one", URL: "http://provider-one.example:8080"},
+			},
+		},
+		{
+			Name: "provider-two",
+			Users: []ProxyRotationUserConfig{
+				{Name: "user-one", URL: "http://provider-two.example:8080"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	httpRequest, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	httpRequest = httpRequest.WithContext(context.WithValue(
+		httpRequest.Context(),
+		proxySelectionTrackerContextKey{},
+		&proxySelectionTracker{requestID: "request-one"},
+	))
+
+	_, err = trackSelectedProxyURL(httpRequest, selector.Select)
+	require.NoError(t, err)
+	initialLease, found := SelectedProxySelection(httpRequest)
+	require.True(t, found)
+
+	selector.ReportFailure(initialLease)
+	require.NotEqual(t, initialLease.Generation, selector.Acquire().Generation)
+
+	headers := http.Header{}
+	headers.Set(proxySelectionTrackingHeader, "request-one")
+	response := &colly.Response{
+		StatusCode: 0,
+		Request: &colly.Request{
+			Headers: &headers,
+			Ctx:     colly.NewContext(),
+		},
+	}
+
+	applyTrackedProxySelection(response)
+	trackedLease, found := selectedProxySelectionFromResponse(response)
+	require.True(t, found)
+	require.Equal(t, initialLease, trackedLease)
 }
 
 func TestHandleCollectorErrorHandlesNilResponse(t *testing.T) {


### PR DESCRIPTION
## Summary
- promote `ProxyLeaseSelector` to own provider-aware rotation, cooldowns, start-provider selection, and exhausted-pool errors
- wire `NewService` through lease selectors for provider configs and legacy flat proxy lists
- move Colly proxy attribution into `utils/crawler`, including tracked lease preservation for redirects and neutral status lease release

## Tests
- `timeout -k 350s -s SIGKILL 350s make ci`