### PR TITLE
fix: reuse least-reserved healthy proxy lease when all are reserved

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,7 @@ only the helpers they need.
   forwarding, and one-shot render helpers.
 - `configfile`: Strict YAML config loading with scalar-only environment
   interpolation, explicit missing-variable errors, no default-substitution
-  syntax, and known-field decoding.
+  syntax, single-document stream validation, and known-field decoding.
 - `crawler`: Shared crawling helpers, including provider/user-aware proxy lease
   selection and operation-scoped failed-lease tracking for scrape batches.
 - `file`: Filesystem helpers (delete, close, read/write convenience).
@@ -50,7 +50,9 @@ only the helpers they need.
 - `ProxyLeaseSelector` owns global provider/user rotation state. It keeps a
   successful lease sticky until failure, then advances to the next provider
   immediately while advancing the failed provider's next user for the next
-  return.
+  return. When all healthy leases are already reserved by in-flight requests, it
+  reuses the least-reserved healthy lease instead of treating reservations as
+  candidate exhaustion.
 - `ProxyLeaseAttemptScope` is caller-created for one scrape or request batch. It
   remembers which leases failed during that operation, skips those leases on
   later acquisitions, and returns `ErrProxyLeaseCandidatesExhausted` once every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes 🐛
+- Reuse the least-reserved healthy proxy lease when every configured lease is already reserved by in-flight requests.
+- Reject trailing YAML documents in `configfile` loads instead of silently ignoring documents after the first one.
+
+### Testing 🧪
+- Add a crawler regression covering saturated proxy lease selection through the public HTTP proxy selector path.
+- Add a configfile regression for multi-document YAML streams.
+
 ## [v0.15.1] - 2026-05-01
 
 ### Features ✨

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ projects.
 Reusable crawler primitives for proxy-aware scraping workloads.
 
 - **ProxyLeaseSelector** - Select provider/user-aware proxy leases, keep
-  successful leases sticky, and rotate providers immediately after a reported
+  successful leases sticky, reuse the least-reserved healthy lease under
+  concurrency saturation, and rotate providers immediately after a reported
   failure.
 - **ProxyLeaseAttemptScope** - Track failed leases for one scrape or request
   batch so callers can skip candidates that already failed during that
@@ -32,7 +33,8 @@ Strict YAML configuration loading for applications.
 
 - **LoadYAML(path string, target any) error** - Read a YAML config file, expand
   environment variables only inside YAML scalar values, reject missing
-  environment variables, and decode with known-field validation.
+  environment variables and trailing YAML documents, and decode with known-field
+  validation.
 - **LoadYAMLBytes(configPayload []byte, target any) error** - Apply the same
   contract to already-read YAML bytes.
 - **InterpolateYAML(configPayload []byte) ([]byte, error)** - Expand YAML scalar

--- a/configfile/configfile.go
+++ b/configfile/configfile.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"regexp"
@@ -119,15 +120,18 @@ func LoadYAMLBytes(configPayload []byte, target any) error {
 	if decodeError := decoder.Decode(target); decodeError != nil {
 		return fmt.Errorf("%w: %w", ErrParse, decodeError)
 	}
+	if streamError := requireYAMLDecoderEOF(decoder); streamError != nil {
+		return streamError
+	}
 
 	return nil
 }
 
 // InterpolateYAML expands environment variables only inside YAML scalar nodes.
 func InterpolateYAML(configPayload []byte) ([]byte, error) {
-	var rootNode yaml.Node
-	if unmarshalError := yaml.Unmarshal(configPayload, &rootNode); unmarshalError != nil {
-		return nil, fmt.Errorf("%w: %w", ErrParse, unmarshalError)
+	rootNode, decodeError := decodeSingleYAMLDocument(configPayload)
+	if decodeError != nil {
+		return nil, decodeError
 	}
 
 	missingVariableSet := make(map[string]struct{})
@@ -143,6 +147,33 @@ func InterpolateYAML(configPayload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %w", ErrParse, marshalError)
 	}
 	return interpolatedPayload, nil
+}
+
+func decodeSingleYAMLDocument(configPayload []byte) (yaml.Node, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(configPayload))
+	var document yaml.Node
+	if decodeError := decoder.Decode(&document); decodeError != nil {
+		if errors.Is(decodeError, io.EOF) {
+			return yaml.Node{}, nil
+		}
+		return yaml.Node{}, fmt.Errorf("%w: %w", ErrParse, decodeError)
+	}
+	if streamError := requireYAMLDecoderEOF(decoder); streamError != nil {
+		return yaml.Node{}, streamError
+	}
+	return document, nil
+}
+
+func requireYAMLDecoderEOF(decoder *yaml.Decoder) error {
+	var trailingDocument yaml.Node
+	trailingDecodeError := decoder.Decode(&trailingDocument)
+	if errors.Is(trailingDecodeError, io.EOF) {
+		return nil
+	}
+	if trailingDecodeError != nil {
+		return fmt.Errorf("%w: %w", ErrParse, trailingDecodeError)
+	}
+	return fmt.Errorf("%w: trailing YAML document", ErrParse)
 }
 
 func validateDecodeTarget(target any) error {

--- a/configfile/configfile_test.go
+++ b/configfile/configfile_test.go
@@ -151,6 +151,56 @@ func TestLoadYAMLBytesRejectsUnknownFields(testingHandle *testing.T) {
 	}
 }
 
+func TestLoadYAMLBytesRejectsTrailingDocuments(testingHandle *testing.T) {
+	var decoded configFileFixture
+	loadError := LoadYAMLBytes([]byte(strings.TrimSpace(`
+server:
+  enabled: true
+---
+server:
+  max_workers: 12
+`)), &decoded)
+
+	if !errors.Is(loadError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", loadError)
+	}
+	if !strings.Contains(loadError.Error(), "trailing YAML document") {
+		testingHandle.Fatalf("expected trailing document error, got %v", loadError)
+	}
+}
+
+func TestLoadYAMLBytesRejectsTrailingDocumentAfterStrictDecode(testingHandle *testing.T) {
+	originalMarshalYAML := marshalYAML
+	marshalYAML = func(input any) ([]byte, error) {
+		return []byte("server: {}\n---\nserver: {}\n"), nil
+	}
+	testingHandle.Cleanup(func() {
+		marshalYAML = originalMarshalYAML
+	})
+
+	var decoded configFileFixture
+	loadError := LoadYAMLBytes([]byte("server: {}\n"), &decoded)
+	if !errors.Is(loadError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", loadError)
+	}
+	if !strings.Contains(loadError.Error(), "trailing YAML document") {
+		testingHandle.Fatalf("expected trailing document error, got %v", loadError)
+	}
+}
+
+func TestInterpolateYAMLAcceptsEmptyPayload(testingHandle *testing.T) {
+	if _, interpolateError := InterpolateYAML(nil); interpolateError != nil {
+		testingHandle.Fatalf("expected empty YAML payload to interpolate, got %v", interpolateError)
+	}
+}
+
+func TestInterpolateYAMLRejectsMalformedTrailingDocument(testingHandle *testing.T) {
+	_, interpolateError := InterpolateYAML([]byte("server: {}\n---\nserver: [\n"))
+	if !errors.Is(interpolateError, ErrParse) {
+		testingHandle.Fatalf("expected ErrParse, got %v", interpolateError)
+	}
+}
+
 func TestInterpolateYAMLReportsMissingEnvironmentVariables(testingHandle *testing.T) {
 	testingHandle.Setenv(testScalarStringName, "available")
 	unsetEnvironment(testingHandle, testMissingEnvironmentNameA)

--- a/crawler/proxy_lease_selector_test.go
+++ b/crawler/proxy_lease_selector_test.go
@@ -44,6 +44,38 @@ func TestProxyLeaseSelectorAcquiresDistinctLeasesAndReusesReleasedSuccess(t *tes
 	require.Equal(t, firstLease.ProxyURL, reusedLease.ProxyURL)
 }
 
+func TestProxyLeaseSelectorReusesLeastReservedHealthyLeaseWhenAllReserved(t *testing.T) {
+	t.Parallel()
+
+	selector, err := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+		Name: "provider-one",
+		Users: []ProxyRotationUserConfig{
+			{Name: "user-one", URL: "http://provider-one-user-one.example:8080"},
+			{Name: "user-two", URL: "http://provider-one-user-two.example:8080"},
+		},
+	}})
+	require.NoError(t, err)
+
+	firstLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	secondLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodGet, "https://example.com/product", nil)
+	require.NoError(t, err)
+	selectedProxyURL, err := selector.Select(request)
+	require.NoError(t, err)
+	require.Equal(t, firstLease.ProxyURL, selectedProxyURL.String())
+
+	selectedLease, found := SelectedProxySelection(request)
+	require.True(t, found)
+	require.Equal(t, firstLease.ProxyURL, selectedLease.ProxyURL)
+
+	leastReservedLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, secondLease.ProxyURL, leastReservedLease.ProxyURL)
+}
+
 func TestProxyLeaseSelectorAcquireForRequestReusesAttachedLease(t *testing.T) {
 	t.Parallel()
 
@@ -198,8 +230,9 @@ func TestProxyLeaseSelectorValidationDuplicateAndReleaseBranches(t *testing.T) {
 	require.Equal(t, "http://shared.example:8080", firstLease.ProxyURL)
 	require.Equal(t, "http://unique.example:8080", secondLease.ProxyURL)
 
-	_, err = selector.AcquireRequired()
-	require.ErrorIs(t, err, ErrProxyLeaseCandidatesExhausted)
+	saturatedLease, err := selector.AcquireRequired()
+	require.NoError(t, err)
+	require.Equal(t, firstLease.ProxyURL, saturatedLease.ProxyURL)
 
 	selector.Release(firstLease)
 	reusedLease := selector.Acquire()
@@ -518,7 +551,8 @@ func TestProxyLeaseSelectorNilInvalidAndInternalFallbackBranches(t *testing.T) {
 
 	selector.reservations = map[string]int{"http://proxy-one.example:8080": 1}
 	lease := selector.Acquire()
-	require.False(t, lease.Valid())
+	require.True(t, lease.Valid())
+	require.Equal(t, "http://proxy-one.example:8080", lease.ProxyURL)
 
 	emptySelector := &ProxyLeaseSelector{reservations: map[string]int{}}
 	require.False(t, emptySelector.Acquire().Valid())

--- a/crawler/proxy_rotation_selector.go
+++ b/crawler/proxy_rotation_selector.go
@@ -539,7 +539,7 @@ func (selector *ProxyLeaseSelector) acquireLocked() ProxyLease {
 		}
 	}
 
-	return ProxyLease{}
+	return selector.leastReservedAvailableLeaseLocked()
 }
 
 func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(providerIndex int) (ProxyLease, bool) {
@@ -568,6 +568,37 @@ func (selector *ProxyLeaseSelector) firstUnreservedLeaseFromProviderLocked(provi
 		return selector.leaseForProviderUser(provider, candidateUser), true
 	}
 	return ProxyLease{}, false
+}
+
+func (selector *ProxyLeaseSelector) leastReservedAvailableLeaseLocked() ProxyLease {
+	selectedReservationCount := 0
+	var selectedLease ProxyLease
+
+	for providerOffset := 0; providerOffset < len(selector.providers); providerOffset++ {
+		providerIndex := (selector.activeProvider + providerOffset) % len(selector.providers)
+		provider := selector.providers[providerIndex]
+		if len(provider.users) == 0 {
+			continue
+		}
+		userIndex := provider.nextUser
+		if userIndex < 0 || userIndex >= len(provider.users) {
+			userIndex = 0
+		}
+		for userOffset := 0; userOffset < len(provider.users); userOffset++ {
+			candidateUserIndex := (userIndex + userOffset) % len(provider.users)
+			candidateUser := provider.users[candidateUserIndex]
+			if !selector.isAvailableLocked(candidateUser.raw) {
+				continue
+			}
+			reservationCount := selector.reservations[candidateUser.raw]
+			if !selectedLease.Valid() || reservationCount < selectedReservationCount {
+				selectedLease = selector.leaseForProviderUser(provider, candidateUser)
+				selectedReservationCount = reservationCount
+			}
+		}
+	}
+
+	return selectedLease
 }
 
 func (selector *ProxyLeaseSelector) leaseForProviderUser(provider proxyRotationProvider, user proxyRotationUser) ProxyLease {

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -51,6 +51,18 @@ Unlike Client.Chat, Factory.Chat assumes the caller passes a non-nil context and
 
 Chat marshals the request payload directly with json.Marshal even when ResponseFormat.Schema contains malformed JSON; json.RawMessage does not validate its contents, so json.Marshal succeeds and the client proceeds to POST an invalid body, returning a transport/HTTP error instead of failing fast with an encoding error (e.g., the schema used in TestClientChatFailsWhenMarshallingRequestPayload). This lets malformed response formats slip through and results in requests the API will reject.
 
+- [x] [UT-307] Allow lease reuse when all proxies are currently reserved. (Return the least-reserved healthy proxy instead of exhausting candidates when concurrent in-flight requests exceed the configured proxy count.)
+
+Returning an empty lease when every configured proxy is reserved makes `acquire()` emit `ErrProxyLeaseCandidatesExhausted`, which bubbles through `Select` into HTTP transport proxy callbacks and fails requests even though healthy proxies exist.
+
+Resolved: `ProxyLeaseSelector` now falls back to the least-reserved healthy lease after all unreserved candidates are occupied, while cooldown-unavailable candidates remain skipped. Added regression coverage for saturated public `Select` behavior and updated lease-selector expectations/docs/changelog. Changed files: `crawler/proxy_rotation_selector.go`, `crawler/proxy_lease_selector_test.go`, `README.md`, `ARCHITECTURE.md`, `CHANGELOG.md`, `issues.md/ISSUES.md`. Verified with `timeout -k 350s -s SIGKILL 350s make test`, `timeout -k 350s -s SIGKILL 350s make lint`, and `timeout -k 350s -s SIGKILL 350s make ci`.
+
+- [x] [UT-308] Reject trailing YAML documents after strict decode. (Require strict config loads to fail when a YAML stream contains more than one document instead of silently accepting only the first document.)
+
+The strict config loader performs one YAML decode and returns success without requiring the next decode to be `io.EOF`, so later YAML documents can be ignored while operators believe those settings were applied.
+
+Resolved: `configfile` now decodes exactly one YAML document before interpolation and requires EOF after the strict `KnownFields(true)` decode. Added `LoadYAMLBytes` and interpolation regressions for trailing documents, malformed trailing documents, and the final strict-decode EOF check; updated configfile docs/changelog. Changed files: `configfile/configfile.go`, `configfile/configfile_test.go`, `README.md`, `ARCHITECTURE.md`, `CHANGELOG.md`, `issues.md/ISSUES.md`. Verified with `timeout -k 350s -s SIGKILL 350s make test`, `timeout -k 350s -s SIGKILL 350s make lint`, and `timeout -k 350s -s SIGKILL 350s make ci`.
+
 ## Maintenance (407–449)
 
 - [x] [UT-410] Extract a shared browser transport runtime beneath jseval. (Add `browsertransport` with transport profiles, reusable sessions, SOCKS forwarding, HTTP client helpers, and one-shot rendering; make `jseval` a compatibility wrapper with migrated coverage.)


### PR DESCRIPTION
- Fall back to least-reserved healthy proxy lease instead of exhausting candidates under concurrency saturation
- Reject trailing YAML documents after strict config decode to prevent silent ignores
- Add regression tests for saturated proxy lease selection and YAML multi-document rejection
- Update documentation and changelog to reflect these improvements