### PR TITLE
Fix UT-309 proxy lease finalization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,7 +52,9 @@ only the helpers they need.
   immediately while advancing the failed provider's next user for the next
   return. When all healthy leases are already reserved by in-flight requests, it
   reuses the least-reserved healthy lease instead of treating reservations as
-  candidate exhaustion.
+  candidate exhaustion. Neutral terminal crawler responses release their lease
+  without recording proxy success or failure, so reservations only reflect
+  active in-flight requests.
 - `ProxyLeaseAttemptScope` is caller-created for one scrape or request batch. It
   remembers which leases failed during that operation, skips those leases on
   later acquisitions, and returns `ErrProxyLeaseCandidatesExhausted` once every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## [Unreleased]
 
 ### Bug Fixes 🐛
+- Release crawler proxy leases on neutral terminal response paths so binary responses, page-not-found titles, no-title exhaustion, and incomplete-content exhaustion do not leave stale reservations behind.
 - Reuse the least-reserved healthy proxy lease when every configured lease is already reserved by in-flight requests.
 - Reject trailing YAML documents in `configfile` loads instead of silently ignoring documents after the first one.
 
 ### Testing 🧪
+- Add crawler response regression coverage for neutral terminal proxy lease release.
 - Add a crawler regression covering saturated proxy lease selection through the public HTTP proxy selector path.
 - Add a configfile regression for multi-document YAML streams.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Reusable crawler primitives for proxy-aware scraping workloads.
 
 - **ProxyLeaseSelector** - Select provider/user-aware proxy leases, keep
   successful leases sticky, reuse the least-reserved healthy lease under
-  concurrency saturation, and rotate providers immediately after a reported
-  failure.
+  concurrency saturation, release neutral terminal responses without poisoning
+  proxy health, and rotate providers immediately after a reported failure.
 - **ProxyLeaseAttemptScope** - Track failed leases for one scrape or request
   batch so callers can skip candidates that already failed during that
   operation and stop with a typed exhausted-candidates error.

--- a/crawler/response.go
+++ b/crawler/response.go
@@ -75,6 +75,7 @@ func (processor *responseProcessor) handleResponse(resp *colly.Response) {
 
 	for _, handler := range processor.responseHandlers {
 		if handler.HandleBinaryResponse(resp, productID, fileExtension) {
+			processor.releaseProxyLease(resp)
 			return
 		}
 	}
@@ -86,6 +87,7 @@ func (processor *responseProcessor) handleResponse(resp *colly.Response) {
 	if pageTitleText == "" && domTitleText == "" {
 		processor.logger.Warning("No title found for %s product: %s", processor.platformID, productID)
 		if !processor.retryHandler.Retry(resp, RetryOptions{}) {
+			processor.releaseProxyLease(resp)
 			processor.SendFinalResult(resp, false, titleNotFoundMessage)
 		}
 		return
@@ -110,6 +112,7 @@ func (processor *responseProcessor) handleResponse(resp *colly.Response) {
 		resp.Ctx.Put(ctxProductErrorKey, pageNotFoundText)
 		resp.Ctx.Put(ctxProductNotFoundFlag, true)
 		processor.logger.Error("Product not found for ProductID: %s", productID)
+		processor.releaseProxyLease(resp)
 		processor.SendFinalResult(resp, false, pageNotFoundText)
 		return
 	}
@@ -136,6 +139,9 @@ func (processor *responseProcessor) handleResponse(resp *colly.Response) {
 					retryDecision.ResolvedLogMessage(),
 				)
 			} else {
+				if retryDecision.Policy != RetryPolicyRotateProxy {
+					processor.releaseProxyLease(resp)
+				}
 				processor.SendFinalResult(resp, false, retryDecision.Message)
 				return
 			}
@@ -149,6 +155,7 @@ func (processor *responseProcessor) handleResponse(resp *colly.Response) {
 		processor.persistHTMLSnapshot(productID, resp.Body)
 		if !processor.retryHandler.Retry(resp, RetryOptions{}) {
 			resp.Ctx.Put(ctxProductErrorKey, detailIncompleteMessage)
+			processor.releaseProxyLease(resp)
 			processor.SendFinalResult(resp, false, detailIncompleteMessage)
 		}
 		return
@@ -222,6 +229,19 @@ func (processor *responseProcessor) recordProxySuccess(resp *colly.Response) {
 		}
 	}
 	processor.proxyTracker.RecordSuccess(proxyURL)
+}
+
+func (processor *responseProcessor) releaseProxyLease(resp *colly.Response) {
+	if processor.proxyTracker == nil {
+		return
+	}
+	lease, found := selectedProxySelectionFromResponse(resp)
+	if !found {
+		return
+	}
+	if releaser, ok := processor.proxyTracker.(proxyLeaseReleaser); ok {
+		releaser.Release(lease)
+	}
 }
 
 func (processor *responseProcessor) retryByDecision(resp *colly.Response, decision RetryDecision) bool {

--- a/crawler/response_test.go
+++ b/crawler/response_test.go
@@ -709,6 +709,180 @@ func TestHandleResponseBinaryHandlerContinuesWhenReturningFalse(t *testing.T) {
 	require.Equal(t, 1, passThroughHandler.afterEvalCalls)
 }
 
+func TestHandleResponseReleasesNeutralProxyLeaseBeforeTerminalReturn(t *testing.T) {
+	testCases := []struct {
+		name             string
+		body             []byte
+		requestURL       string
+		responseHandlers []ResponseHandler
+		platformHooks    PlatformHooks
+		expectResult     bool
+		expectedError    string
+	}{
+		{
+			name:             "binary handler short circuit",
+			body:             []byte{0xFF, 0xD8, 0xFF, 0xE0},
+			requestURL:       "https://example.com/images/photo.jpg",
+			responseHandlers: []ResponseHandler{&recordingResponseHandler{binaryReturnValue: true}},
+			platformHooks:    noopPlatformHooks{},
+		},
+		{
+			name:          "page not found title",
+			body:          []byte(`<html><head><title>Page Not Found</title></head><body></body></html>`),
+			requestURL:    "https://example.com/dp/PROD404",
+			platformHooks: noopPlatformHooks{},
+			expectResult:  true,
+			expectedError: pageNotFoundText,
+		},
+		{
+			name:          "missing title retry exhausted",
+			body:          []byte(`<html><head></head><body></body></html>`),
+			requestURL:    "https://example.com/dp/NOTITLE",
+			platformHooks: noopPlatformHooks{},
+			expectResult:  true,
+			expectedError: titleNotFoundMessage,
+		},
+		{
+			name:          "incomplete content retry exhausted",
+			body:          []byte(`<html><head><title>Title</title></head><body></body></html>`),
+			requestURL:    "https://example.com/dp/INCOMPLETE",
+			platformHooks: incompleteContentHooks{},
+			expectResult:  true,
+			expectedError: detailIncompleteMessage,
+		},
+		{
+			name:       "default retry policy exhausted",
+			body:       []byte(`<html><head><title>Title</title></head><body><div id="wrong-context"></div></body></html>`),
+			requestURL: "https://example.com/dp/DEFAULT-RETRY",
+			platformHooks: retryingPlatformHooks{
+				retryMessage:       "retry default",
+				retryPolicy:        RetryPolicyDefault,
+				exhaustionBehavior: RetryExhaustionBehaviorFail,
+			},
+			expectResult:  true,
+			expectedError: "retry default",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			results := make(chan *Result, 1)
+			selector, selectorErr := NewProxyLeaseSelector([]ProxyRotationProviderConfig{{
+				Name: "provider-one",
+				Users: []ProxyRotationUserConfig{
+					{Name: "user-one", URL: "http://proxy-one.example:8080"},
+					{Name: "user-two", URL: "http://proxy-two.example:8080"},
+				},
+			}})
+			require.NoError(t, selectorErr)
+			tracker := &recordingLeaseTracker{selector: selector}
+			lease, leaseErr := selector.AcquireRequired()
+			require.NoError(t, leaseErr)
+
+			processor := &responseProcessor{
+				platformID:       "TEST",
+				platformHooks:    testCase.platformHooks,
+				retryHandler:     newRetryHandler(ScraperConfig{RetryCount: 0}, noopLogger{}),
+				ruleEvaluator:    &countingRuleEvaluator{configured: 1},
+				proxyTracker:     tracker,
+				results:          results,
+				logger:           noopLogger{},
+				responseHandlers: testCase.responseHandlers,
+			}
+
+			response := newTestResponse("LEASE-PRODUCT")
+			response.Body = testCase.body
+			response.StatusCode = http.StatusOK
+			headers := http.Header{}
+			response.Headers = &headers
+			pageURL, parseErr := url.Parse(testCase.requestURL)
+			require.NoError(t, parseErr)
+			response.Request.URL = pageURL
+			response.Request.ProxyURL = lease.ProxyURL
+			attachTrackedProxySelection(response.Request, lease)
+
+			processor.handleResponse(response)
+
+			if testCase.expectResult {
+				result := <-results
+				require.False(t, result.Success)
+				require.Equal(t, testCase.expectedError, result.ErrorMessage)
+			} else {
+				select {
+				case result := <-results:
+					t.Fatalf("expected no result for neutral terminal path, got %+v", result)
+				default:
+				}
+			}
+
+			require.Equal(t, []ProxyLease{lease}, tracker.releases)
+			require.Empty(t, tracker.successes)
+			require.Empty(t, tracker.failures)
+			require.Empty(t, tracker.criticalFailures)
+
+			nextLease, nextLeaseErr := selector.AcquireRequired()
+			require.NoError(t, nextLeaseErr)
+			require.Equal(t, lease.ProxyURL, nextLease.ProxyURL)
+		})
+	}
+}
+
+type recordingLeaseTracker struct {
+	selector         *ProxyLeaseSelector
+	releases         []ProxyLease
+	successes        []ProxyLease
+	failures         []ProxyLease
+	criticalFailures []ProxyLease
+}
+
+func (tracker *recordingLeaseTracker) IsAvailable(proxyURL string) bool {
+	return tracker.selector.IsAvailable(proxyURL)
+}
+
+func (tracker *recordingLeaseTracker) RecordSuccess(proxyURL string) {
+	lease, found := tracker.selector.SelectionForProxyURL(proxyURL)
+	if !found {
+		return
+	}
+	tracker.ReportSuccess(lease)
+}
+
+func (tracker *recordingLeaseTracker) RecordFailure(proxyURL string) {
+	lease, found := tracker.selector.SelectionForProxyURL(proxyURL)
+	if !found {
+		return
+	}
+	tracker.ReportFailure(lease)
+}
+
+func (tracker *recordingLeaseTracker) RecordCriticalFailure(proxyURL string) {
+	lease, found := tracker.selector.SelectionForProxyURL(proxyURL)
+	if !found {
+		return
+	}
+	tracker.ReportCriticalFailure(lease)
+}
+
+func (tracker *recordingLeaseTracker) Release(lease ProxyLease) {
+	tracker.releases = append(tracker.releases, lease)
+	tracker.selector.Release(lease)
+}
+
+func (tracker *recordingLeaseTracker) ReportSuccess(lease ProxyLease) {
+	tracker.successes = append(tracker.successes, lease)
+	tracker.selector.ReportSuccess(lease)
+}
+
+func (tracker *recordingLeaseTracker) ReportFailure(lease ProxyLease) {
+	tracker.failures = append(tracker.failures, lease)
+	tracker.selector.ReportFailure(lease)
+}
+
+func (tracker *recordingLeaseTracker) ReportCriticalFailure(lease ProxyLease) {
+	tracker.criticalFailures = append(tracker.criticalFailures, lease)
+	tracker.selector.ReportCriticalFailure(lease)
+}
+
 func loadDocumentFromFile(t *testing.T, path string) *goquery.Document {
 	t.Helper()
 	file, err := os.Open(path)

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -20,6 +20,10 @@ Resolved: added `ProxyLease`, `ProxyLeaseSelector`, required/acquire/report/rele
 
 ## BugFixes (300–399)
 
+- [x] [UT-309] Release crawler proxy leases on neutral terminal responses. (Ensure response paths that finish without retrying or evaluating HTML, such as binary handlers, page-not-found titles, no-title exhaustion, and incomplete-content exhaustion, release the reserved proxy lease instead of leaving stale reservations behind.)
+
+Resolved: response processing now releases tracked proxy leases for neutral terminal response paths without reporting proxy success or failure. Added crawler regression coverage for binary short-circuit handlers, page-not-found titles, missing-title exhaustion, incomplete-content exhaustion, and default retry-policy exhaustion; updated crawler docs and changelog. Changed files: `crawler/response.go`, `crawler/response_test.go`, `README.md`, `ARCHITECTURE.md`, `CHANGELOG.md`, `issues.md/ISSUES.md`. Verified with `timeout -k 350s -s SIGKILL 350s make test`, `timeout -k 350s -s SIGKILL 350s make lint`, and `timeout -k 350s -s SIGKILL 350s make ci`.
+
 - [x] [UT-306] Build SOCKS dial targets with `net.JoinHostPort`. (Use bracket-aware host:port assembly in the SOCKS forwarder and add IPv6 dial-target regression coverage.)
 
 The forwarder assembled upstream dial targets with raw string formatting, which


### PR DESCRIPTION
## Summary
- Release tracked crawler proxy leases on neutral terminal response paths without reporting proxy success or failure.
- Cover binary short-circuit handlers, page-not-found titles, missing-title exhaustion, incomplete-content exhaustion, and default retry-policy exhaustion.
- Update crawler docs, changelog, and UT-309 issue log.

## Validation
- timeout -k 350s -s SIGKILL 350s make test
- timeout -k 350s -s SIGKILL 350s make lint
- timeout -k 350s -s SIGKILL 350s make ci